### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -1,14 +1,13 @@
 package grocksdb
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestBackupEngine(t *testing.T) {
-	db := newTestDB(t, "TestDBBackup", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	var (
@@ -91,8 +90,7 @@ func TestBackupEngine(t *testing.T) {
 	})
 
 	t.Run("restoreFromLatest", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "gorocksdb-restoreFromLatest")
-		require.Nil(t, err)
+		dir := t.TempDir()
 
 		ro := NewRestoreOptions()
 		defer ro.Destroy()
@@ -104,8 +102,7 @@ func TestBackupEngine(t *testing.T) {
 		infos := engine.GetInfo()
 		require.Equal(t, 1, len(infos))
 
-		dir, err := ioutil.TempDir("", "gorocksdb-restoreFromBackup")
-		require.Nil(t, err)
+		dir := t.TempDir()
 
 		ro := NewRestoreOptions()
 		defer ro.Destroy()

--- a/cf_test.go
+++ b/cf_test.go
@@ -1,15 +1,13 @@
 package grocksdb
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestColumnFamilyOpen(t *testing.T) {
-	dir, err := ioutil.TempDir("", "gorocksdb-TestColumnFamilyOpen")
-	require.Nil(t, err)
+	dir := t.TempDir()
 
 	givenNames := []string{"default", "guide"}
 	opts := NewDefaultOptions()
@@ -29,8 +27,7 @@ func TestColumnFamilyOpen(t *testing.T) {
 }
 
 func TestColumnFamilyCreateDrop(t *testing.T) {
-	dir, err := ioutil.TempDir("", "gorocksdb-TestColumnFamilyCreate")
-	require.Nil(t, err)
+	dir := t.TempDir()
 
 	opts := NewDefaultOptions()
 	opts.SetCreateIfMissingColumnFamilies(true)
@@ -55,8 +52,7 @@ func TestColumnFamilyCreateDrop(t *testing.T) {
 }
 
 func TestColumnFamilyBatchPutGet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "gorocksdb-TestColumnFamilyPutGet")
-	require.Nil(t, err)
+	dir := t.TempDir()
 
 	givenNames := []string{"default", "guide"}
 	opts := NewDefaultOptions()
@@ -115,8 +111,7 @@ func TestColumnFamilyBatchPutGet(t *testing.T) {
 }
 
 func TestColumnFamilyPutGetDelete(t *testing.T) {
-	dir, err := ioutil.TempDir("", "gorocksdb-TestColumnFamilyPutGet")
-	require.Nil(t, err)
+	dir := t.TempDir()
 
 	givenNames := []string{"default", "guide"}
 	opts := NewDefaultOptions()
@@ -190,16 +185,15 @@ func TestColumnFamilyPutGetDelete(t *testing.T) {
 	}
 }
 
-func newTestDBCF(t *testing.T, name string) (db *DB, cfh []*ColumnFamilyHandle, cleanup func()) {
-	dir, err := ioutil.TempDir("", "gorocksdb-TestColumnFamilyPutGet")
-	require.Nil(t, err)
+func newTestDBCF(t *testing.T) (db *DB, cfh []*ColumnFamilyHandle, cleanup func()) {
+	dir := t.TempDir()
 
 	givenNames := []string{"default", "guide"}
 	opts := NewDefaultOptions()
 	opts.SetCreateIfMissingColumnFamilies(true)
 	opts.SetCreateIfMissing(true)
 	opts.SetCompression(ZLibCompression)
-	db, cfh, err = OpenDbColumnFamilies(opts, dir, givenNames, []*Options{opts, opts})
+	db, cfh, err := OpenDbColumnFamilies(opts, dir, givenNames, []*Options{opts, opts})
 	require.Nil(t, err)
 	cleanup = func() {
 		for _, cf := range cfh {
@@ -211,7 +205,7 @@ func newTestDBCF(t *testing.T, name string) (db *DB, cfh []*ColumnFamilyHandle, 
 }
 
 func TestColumnFamilyMultiGet(t *testing.T) {
-	db, cfh, cleanup := newTestDBCF(t, "TestDBMultiGet")
+	db, cfh, cleanup := newTestDBCF(t)
 	defer cleanup()
 
 	var (

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -1,7 +1,6 @@
 package grocksdb
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -10,13 +9,11 @@ import (
 
 func TestCheckpoint(t *testing.T) {
 
-	suffix := "checkpoint"
-	dir, err := ioutil.TempDir("", "gorocksdb-"+suffix)
-	require.Nil(t, err)
-	err = os.RemoveAll(dir)
+	dir := t.TempDir()
+	err := os.RemoveAll(dir)
 	require.Nil(t, err)
 
-	db := newTestDB(t, "TestCheckpoint", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	// insert keys

--- a/compaction_filter_test.go
+++ b/compaction_filter_test.go
@@ -14,7 +14,7 @@ func TestCompactionFilter(t *testing.T) {
 		changeValNew = []byte("new")
 		deleteKey    = []byte("delete")
 	)
-	db := newTestDB(t, "TestCompactionFilter", func(opts *Options) {
+	db := newTestDB(t, func(opts *Options) {
 		opts.SetCompactionFilter(&mockCompactionFilter{
 			filter: func(_ int, key, val []byte) (remove bool, newVal []byte) {
 				if bytes.Equal(key, changeKey) {

--- a/comparator_test.go
+++ b/comparator_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestComparator(t *testing.T) {
-	db, opts := newTestDBAndOpts(t, "TestComparator", func(opts *Options) {
+	db, opts := newTestDBAndOpts(t, func(opts *Options) {
 		opts.SetComparator(NewComparator("rev", func(a, b []byte) int {
 			return bytes.Compare(a, b) * -1
 		}))

--- a/db_external_file_test.go
+++ b/db_external_file_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestExternalFile(t *testing.T) {
-	db := newTestDB(t, "TestDBExternalFile", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	envOpts := NewDefaultEnvOptions()

--- a/db_test.go
+++ b/db_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOpenDb(t *testing.T) {
-	db := newTestDB(t, "TestOpenDb", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 	require.EqualValues(t, "0", db.GetProperty("rocksdb.num-immutable-mem-table"))
 	v, success := db.GetIntProperty("rocksdb.num-immutable-mem-table")
@@ -18,7 +18,7 @@ func TestOpenDb(t *testing.T) {
 }
 
 func TestDBCRUD(t *testing.T) {
-	db := newTestDB(t, "TestDBGet", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	var (
@@ -87,7 +87,7 @@ func TestDBCRUDDBPaths(t *testing.T) {
 		targetSizes[i] = uint64(1024 * 1024 * (i + 1))
 	}
 
-	db := newTestDBPathNames(t, "TestDBGet", names, targetSizes, nil)
+	db := newTestDBPathNames(t, names, targetSizes, nil)
 	defer db.Close()
 
 	var (
@@ -147,9 +147,8 @@ func TestDBCRUDDBPaths(t *testing.T) {
 	require.EqualValues(t, v4.Data(), []byte(nil))
 }
 
-func newTestDB(t *testing.T, name string, applyOpts func(opts *Options)) *DB {
-	dir, err := ioutil.TempDir("", "gorocksdb-"+name)
-	require.Nil(t, err)
+func newTestDB(t *testing.T, applyOpts func(opts *Options)) *DB {
+	dir := t.TempDir()
 
 	opts := NewDefaultOptions()
 	// test the ratelimiter
@@ -166,9 +165,8 @@ func newTestDB(t *testing.T, name string, applyOpts func(opts *Options)) *DB {
 	return db
 }
 
-func newTestDBAndOpts(t *testing.T, name string, applyOpts func(opts *Options)) (*DB, *Options) {
-	dir, err := ioutil.TempDir("", "gorocksdb-"+name)
-	require.Nil(t, err)
+func newTestDBAndOpts(t *testing.T, applyOpts func(opts *Options)) (*DB, *Options) {
+	dir := t.TempDir()
 
 	opts := NewDefaultOptions()
 	// test the ratelimiter
@@ -185,9 +183,8 @@ func newTestDBAndOpts(t *testing.T, name string, applyOpts func(opts *Options)) 
 	return db, opts
 }
 
-func newTestDBMultiCF(t *testing.T, name string, columns []string, applyOpts func(opts *Options)) (db *DB, cfh []*ColumnFamilyHandle, cleanup func()) {
-	dir, err := ioutil.TempDir("", "gorocksdb-"+name)
-	require.Nil(t, err)
+func newTestDBMultiCF(t *testing.T, columns []string, applyOpts func(opts *Options)) (db *DB, cfh []*ColumnFamilyHandle, cleanup func()) {
+	dir := t.TempDir()
 
 	opts := NewDefaultOptions()
 	opts.SetCreateIfMissingColumnFamilies(true)
@@ -202,7 +199,7 @@ func newTestDBMultiCF(t *testing.T, name string, columns []string, applyOpts fun
 		options[i] = opts
 	}
 
-	db, cfh, err = OpenDbColumnFamilies(opts, dir, columns, options)
+	db, cfh, err := OpenDbColumnFamilies(opts, dir, columns, options)
 	require.Nil(t, err)
 	cleanup = func() {
 		for _, cf := range cfh {
@@ -213,16 +210,15 @@ func newTestDBMultiCF(t *testing.T, name string, columns []string, applyOpts fun
 	return db, cfh, cleanup
 }
 
-func newTestDBPathNames(t *testing.T, name string, names []string, targetSizes []uint64, applyOpts func(opts *Options)) *DB {
+func newTestDBPathNames(t *testing.T, names []string, targetSizes []uint64, applyOpts func(opts *Options)) *DB {
 	require.EqualValues(t, len(targetSizes), len(names))
 	require.True(t, len(names) > 0)
 
-	dir, err := ioutil.TempDir("", "gorocksdb-"+name)
-	require.Nil(t, err)
+	dir := t.TempDir()
 
 	paths := make([]string, len(names))
 	for i, name := range names {
-		directory, e := ioutil.TempDir("", "gorocksdb-"+name)
+		directory, e := ioutil.TempDir(dir, "gorocksdb-"+name)
 		require.Nil(t, e)
 		paths[i] = directory
 	}
@@ -246,7 +242,7 @@ func newTestDBPathNames(t *testing.T, name string, names []string, targetSizes [
 }
 
 func TestDBMultiGet(t *testing.T) {
-	db := newTestDB(t, "TestDBMultiGet", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	var (
@@ -278,7 +274,7 @@ func TestDBMultiGet(t *testing.T) {
 }
 
 func TestDBGetApproximateSizes(t *testing.T) {
-	db := newTestDB(t, "TestDBGetApproximateSizes", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	// no ranges
@@ -298,7 +294,7 @@ func TestDBGetApproximateSizes(t *testing.T) {
 }
 
 func TestDBGetApproximateSizesCF(t *testing.T) {
-	db := newTestDB(t, "TestDBGetApproximateSizesCF", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	o := NewDefaultOptions()

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIterator(t *testing.T) {
-	db := newTestDB(t, "TestIterator", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	// insert keys
@@ -32,7 +32,7 @@ func TestIterator(t *testing.T) {
 }
 
 func TestIteratorWriteManyThenIter(t *testing.T) {
-	db := newTestDB(t, "TestIteratorMany", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	numKey := 10_000
@@ -61,7 +61,7 @@ func TestIteratorWriteManyThenIter(t *testing.T) {
 }
 
 func TestIteratorCF(t *testing.T) {
-	db, cfs, cleanup := newTestDBMultiCF(t, "TestIteratorCF", []string{"default", "c1", "c2", "c3"}, nil)
+	db, cfs, cleanup := newTestDBMultiCF(t, []string{"default", "c1", "c2", "c3"}, nil)
 	defer cleanup()
 
 	// insert keys

--- a/memory_usage_test.go
+++ b/memory_usage_test.go
@@ -25,7 +25,7 @@ func TestMemoryUsage(t *testing.T) {
 		opts.SetRowCache(rowCache)
 	}
 
-	db := newTestDB(t, "TestMemoryUsage", applyOpts)
+	db := newTestDB(t, applyOpts)
 	defer db.Close()
 
 	// take first memory usage snapshot

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -21,7 +21,7 @@ func TestMergeOperator(t *testing.T) {
 			return givenMerged, true
 		},
 	}
-	db := newTestDB(t, "TestMergeOperator", func(opts *Options) {
+	db := newTestDB(t, func(opts *Options) {
 		opts.SetMergeOperator(merger)
 	})
 	defer db.Close()
@@ -64,7 +64,7 @@ func TestPartialMergeOperator(t *testing.T) {
 			return pMergeResult, true
 		},
 	}
-	db := newTestDB(t, "TestMergeOperator", func(opts *Options) {
+	db := newTestDB(t, func(opts *Options) {
 		opts.SetMergeOperator(merger)
 	})
 	defer db.Close()
@@ -118,7 +118,7 @@ func TestMergeMultiOperator(t *testing.T) {
 			return pMergeResult, true
 		},
 	}
-	db := newTestDB(t, "TestMergeOperator", func(opts *Options) {
+	db := newTestDB(t, func(opts *Options) {
 		opts.SetMergeOperator(merger)
 	})
 	defer db.Close()

--- a/slice_transform_test.go
+++ b/slice_transform_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSliceTransform(t *testing.T) {
-	db := newTestDB(t, "TestSliceTransform", func(opts *Options) {
+	db := newTestDB(t, func(opts *Options) {
 		opts.SetPrefixExtractor(&testSliceTransform{})
 	})
 	defer db.Close()
@@ -29,14 +29,14 @@ func TestSliceTransform(t *testing.T) {
 }
 
 func TestFixedPrefixTransformOpen(t *testing.T) {
-	db := newTestDB(t, "TestFixedPrefixTransformOpen", func(opts *Options) {
+	db := newTestDB(t, func(opts *Options) {
 		opts.SetPrefixExtractor(NewFixedPrefixTransform(3))
 	})
 	defer db.Close()
 }
 
 func TestNewNoopPrefixTransform(t *testing.T) {
-	db := newTestDB(t, "TestNewNoopPrefixTransform", func(opts *Options) {
+	db := newTestDB(t, func(opts *Options) {
 		opts.SetPrefixExtractor(NewNoopPrefixTransform())
 	})
 	defer db.Close()

--- a/transactiondb_test.go
+++ b/transactiondb_test.go
@@ -1,19 +1,18 @@
 package grocksdb
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestOpenTransactionDb(t *testing.T) {
-	db := newTestTransactionDB(t, "TestOpenTransactionDb", nil)
+	db := newTestTransactionDB(t, nil)
 	defer db.Close()
 }
 
 func TestTransactionDBCRUD(t *testing.T) {
-	db := newTestTransactionDB(t, "TestTransactionDBGet", nil)
+	db := newTestTransactionDB(t, nil)
 	defer db.Close()
 
 	var (
@@ -98,7 +97,7 @@ func TestTransactionDBGetForUpdate(t *testing.T) {
 	applyOpts := func(_ *Options, transactionDBOpts *TransactionDBOptions) {
 		transactionDBOpts.SetTransactionLockTimeout(lockTimeoutMilliSec)
 	}
-	db := newTestTransactionDB(t, "TestOpenTransactionDb", applyOpts)
+	db := newTestTransactionDB(t, applyOpts)
 	defer db.Close()
 
 	var (
@@ -122,9 +121,8 @@ func TestTransactionDBGetForUpdate(t *testing.T) {
 	}
 }
 
-func newTestTransactionDB(t *testing.T, name string, applyOpts func(opts *Options, transactionDBOpts *TransactionDBOptions)) *TransactionDB {
-	dir, err := ioutil.TempDir("", "gorockstransactiondb-"+name)
-	require.Nil(t, err)
+func newTestTransactionDB(t *testing.T, applyOpts func(opts *Options, transactionDBOpts *TransactionDBOptions)) *TransactionDB {
+	dir := t.TempDir()
 
 	opts := NewDefaultOptions()
 	opts.SetCreateIfMissing(true)

--- a/write_batch_test.go
+++ b/write_batch_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestWriteBatch(t *testing.T) {
-	db := newTestDB(t, "TestWriteBatch", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	var (
@@ -54,7 +54,7 @@ func TestWriteBatch(t *testing.T) {
 }
 
 func TestWriteBatchIterator(t *testing.T) {
-	db := newTestDB(t, "TestWriteBatchIterator", nil)
+	db := newTestDB(t, nil)
 	defer db.Close()
 
 	var (


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.Nil(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```