### PR TITLE
Build: support minimal link flags

### DIFF
--- a/non_builtin.go
+++ b/non_builtin.go
@@ -1,4 +1,4 @@
-//go:build !testing
+//go:build !testing && !grocksdb_clean_link
 
 package grocksdb
 

--- a/non_builtin_clean_link.go
+++ b/non_builtin_clean_link.go
@@ -1,0 +1,6 @@
+//go:build !testing && grocksdb_clean_link
+
+package grocksdb
+
+// #cgo LDFLAGS: -lrocksdb -pthread -lstdc++ -ldl
+import "C"


### PR DESCRIPTION
~~Removing these flags seems have no side effects, but make life easier with my package manager (nix), where I only need to install librocksdb, rather than installing all the indirect dependencies, those are indirectly brought in anyway.~~

In many cases, we don't need the extra link flags, either because librocksdb already referenced the indirect dependencies by path, or it's not built with it at all, so this PR introduce a build tag `grocksdb_clean_link` to only link minimal dependencies.