### PR TITLE
don't build `rocksdb_property_int`/`rocksdb_property_int_cf` on windows

### DIFF
--- a/db.go
+++ b/db.go
@@ -1235,24 +1235,6 @@ func (db *DB) GetPropertyCF(propName string, cf *ColumnFamilyHandle) (value stri
 	return
 }
 
-// GetIntProperty similar to `GetProperty`, but only works for a subset of properties whose
-// return value is an integer. Return the value by integer.
-func (db *DB) GetIntProperty(propName string) (value uint64, success bool) {
-	cProp := C.CString(propName)
-	success = C.rocksdb_property_int(db.c, cProp, (*C.uint64_t)(&value)) == 0
-	C.free(unsafe.Pointer(cProp))
-	return
-}
-
-// GetIntPropertyCF similar to `GetProperty`, but only works for a subset of properties whose
-// return value is an integer. Return the value by integer.
-func (db *DB) GetIntPropertyCF(propName string, cf *ColumnFamilyHandle) (value uint64, success bool) {
-	cProp := C.CString(propName)
-	success = C.rocksdb_property_int_cf(db.c, cf.c, cProp, (*C.uint64_t)(&value)) == 0
-	C.free(unsafe.Pointer(cProp))
-	return
-}
-
 // CreateColumnFamily create a new column family.
 func (db *DB) CreateColumnFamily(opts *Options, name string) (handle *ColumnFamilyHandle, err error) {
 	var (

--- a/db_test.go
+++ b/db_test.go
@@ -13,9 +13,6 @@ func TestOpenDb(t *testing.T) {
 	db := newTestDB(t, nil)
 	defer db.Close()
 	require.EqualValues(t, "0", db.GetProperty("rocksdb.num-immutable-mem-table"))
-	v, success := db.GetIntProperty("rocksdb.num-immutable-mem-table")
-	require.EqualValues(t, uint64(0), v)
-	require.True(t, success)
 }
 
 func TestDBCRUD(t *testing.T) {

--- a/db_unix.go
+++ b/db_unix.go
@@ -3,6 +3,10 @@
 
 package grocksdb
 
+// #include <stdlib.h>
+// #include "rocksdb/c.h"
+import "C"
+
 import "unsafe"
 
 // GetIntProperty similar to `GetProperty`, but only works for a subset of properties whose

--- a/db_unix.go
+++ b/db_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+// +build !windows
+
+package grocksdb
+
+import "unsafe"
+
+// GetIntProperty similar to `GetProperty`, but only works for a subset of properties whose
+// return value is an integer. Return the value by integer.
+func (db *DB) GetIntProperty(propName string) (value uint64, success bool) {
+	cProp := C.CString(propName)
+	success = C.rocksdb_property_int(db.c, cProp, (*C.uint64_t)(&value)) == 0
+	C.free(unsafe.Pointer(cProp))
+	return
+}
+
+// GetIntPropertyCF similar to `GetProperty`, but only works for a subset of properties whose
+// return value is an integer. Return the value by integer.
+func (db *DB) GetIntPropertyCF(propName string, cf *ColumnFamilyHandle) (value uint64, success bool) {
+	cProp := C.CString(propName)
+	success = C.rocksdb_property_int_cf(db.c, cf.c, cProp, (*C.uint64_t)(&value)) == 0
+	C.free(unsafe.Pointer(cProp))
+	return
+}

--- a/db_unix_test.go
+++ b/db_unix_test.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package grocksdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenDbUnix(t *testing.T) {
+	db := newTestDB(t, nil)
+	defer db.Close()
+	require.EqualValues(t, "0", db.GetProperty("rocksdb.num-immutable-mem-table"))
+	v, success := db.GetIntProperty("rocksdb.num-immutable-mem-table")
+	require.EqualValues(t, uint64(0), v)
+	require.True(t, success)
+}


### PR DESCRIPTION
they are not exported by rocksdb on windows in current version.
see: https://github.com/facebook/rocksdb/pull/11217