### PR TITLE
Add `grocksdb_no_link` build flag to remove builtin link flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ libs:
 
 .PHONY: test
 test:
-	go test -v -count=1 -tags testing
+	go test -v -count=1 -tags testing,grocksdb_no_link

--- a/non_builtin.go
+++ b/non_builtin.go
@@ -1,5 +1,7 @@
-//go:build !testing && !grocksdb_clean_link
+//go:build !grocksdb_no_link && !grocksdb_clean_link
 
+// The default link options, to customize it, you can try build tag `grocksdb_clean_link` for a cleaner set of flags,
+// or `grocksdb_no_link` where you have full control through `CGO_LDFLAGS` environment variable.
 package grocksdb
 
 // #cgo LDFLAGS: -lrocksdb -pthread -lstdc++ -ldl -lm -lzstd -llz4 -lz -lsnappy

--- a/non_builtin_clean_link.go
+++ b/non_builtin_clean_link.go
@@ -1,4 +1,4 @@
-//go:build !testing && grocksdb_clean_link
+//go:build !grocksdb_no_link && grocksdb_clean_link
 
 package grocksdb
 


### PR DESCRIPTION
Closes: #104
user can have full control through `CGO_LDFLAGS` environment variable.