### PR TITLE
add arm64 support for make test using installed libs

### DIFF
--- a/testing_linux_arm64.go
+++ b/testing_linux_arm64.go
@@ -1,0 +1,8 @@
+//go:build testing
+
+package grocksdb
+
+// #cgo CFLAGS: -I${SRCDIR}/dist/linux_arm64/include
+// #cgo CXXFLAGS: -I${SRCDIR}/dist/linux_arm64/include
+// #cgo LDFLAGS: -L${SRCDIR}/dist/linux_arm64/lib -L${SRCDIR}/dist/linux_arm64/lib64 -lrocksdb -pthread -lstdc++ -ldl -lm -lzstd -llz4 -lz -lsnappy
+import "C"


### PR DESCRIPTION
Adds the ability to to run `make libs && make test` on arm64 machines running linux.