### PR TITLE
Fix WriteBatchIterator: doesn’t correctly detect invalid sequences

### DIFF
--- a/write_batch.go
+++ b/write_batch.go
@@ -344,9 +344,11 @@ func (iter *WriteBatchIterator) decodeRecType() WriteBatchRecordType {
 
 func (iter *WriteBatchIterator) decodeVarint() uint64 {
 	v, n := binary.Uvarint(iter.data)
-	if n == 0 {
+	if n > 0 {
+		iter.data = iter.data[n:]
+	} else if n == 0 {
 		iter.err = io.ErrShortBuffer
-	} else if n < 0 {
+	} else {
 		iter.err = errors.New("malformed varint")
 	}
 	return v

--- a/write_batch.go
+++ b/write_batch.go
@@ -4,6 +4,7 @@ package grocksdb
 import "C"
 
 import (
+	"encoding/binary"
 	"errors"
 	"io"
 )
@@ -342,21 +343,11 @@ func (iter *WriteBatchIterator) decodeRecType() WriteBatchRecordType {
 }
 
 func (iter *WriteBatchIterator) decodeVarint() uint64 {
-	var n int
-	var x uint64
-	for shift := uint(0); shift < 64 && n < len(iter.data); shift += 7 {
-		b := uint64(iter.data[n])
-		n++
-		x |= (b & 0x7F) << shift
-		if (b & 0x80) == 0 {
-			iter.data = iter.data[n:]
-			return x
-		}
-	}
-	if n == len(iter.data) {
+	v, n := binary.Uvarint(iter.data)
+	if n == 0 {
 		iter.err = io.ErrShortBuffer
-	} else {
+	} else if n < 0 {
 		iter.err = errors.New("malformed varint")
 	}
-	return 0
+	return v
 }

--- a/write_batch_test.go
+++ b/write_batch_test.go
@@ -89,3 +89,10 @@ func TestWriteBatchIterator(t *testing.T) {
 	// there shouldn't be any left
 	require.False(t, iter.Next())
 }
+
+func TestDecodeVarint(t *testing.T) {
+	t.Parallel()
+
+	wbi := &WriteBatchIterator{data: []byte{0xd7, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f}}
+	require.EqualValues(t, 0, wbi.decodeVarint())
+}


### PR DESCRIPTION
Closes #131 