### PR TITLE
Avoid ReadOptions mutated by reference release in iterator

### DIFF
--- a/comparator_ts_test.go
+++ b/comparator_ts_test.go
@@ -2,6 +2,7 @@ package grocksdb
 
 import (
 	"bytes"
+	"encoding/binary"
 	"runtime"
 	"testing"
 
@@ -17,6 +18,7 @@ func TestComparatorWithTS(t *testing.T) {
 			func(a, b []byte) int {
 				return bytes.Compare(a, b) * -1
 			},
+			binary.LittleEndian.Uint64,
 		)
 		opts.SetComparator(comp)
 	})

--- a/db.go
+++ b/db.go
@@ -1139,14 +1139,14 @@ func (db *DB) WriteWI(opts *WriteOptions, batch *WriteBatchWI) (err error) {
 // ReadOptions given.
 func (db *DB) NewIterator(opts *ReadOptions) *Iterator {
 	cIter := C.rocksdb_create_iterator(db.c, opts.c)
-	return newNativeIteratorWithTS(cIter, opts.timestamp)
+	return newNativeIteratorWithReadOptions(cIter, opts)
 }
 
 // NewIteratorCF returns an Iterator over the the database and column family
 // that uses the ReadOptions given.
 func (db *DB) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator {
 	cIter := C.rocksdb_create_iterator_cf(db.c, opts.c, cf.c)
-	return newNativeIteratorWithTS(cIter, opts.timestamp)
+	return newNativeIteratorWithReadOptions(cIter, opts)
 }
 
 // NewIterators returns iterators from a consistent database state across multiple
@@ -1165,7 +1165,7 @@ func (db *DB) NewIterators(opts *ReadOptions, cfs []*ColumnFamilyHandle) (iters 
 		if err = fromCError(cErr); err == nil {
 			iters = make([]*Iterator, n)
 			for i := range iters {
-				iters[i] = newNativeIteratorWithTS(_iters[i], opts.timestamp)
+				iters[i] = newNativeIteratorWithReadOptions(_iters[i], opts)
 			}
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -1139,7 +1139,7 @@ func (db *DB) WriteWI(opts *WriteOptions, batch *WriteBatchWI) (err error) {
 // ReadOptions given.
 func (db *DB) NewIterator(opts *ReadOptions) *Iterator {
 	cIter := C.rocksdb_create_iterator(db.c, opts.c)
-	return newNativeIterator(cIter)
+	return newNativeIteratorWithTS(cIter, opts.timestamp)
 }
 
 // NewIteratorCF returns an Iterator over the the database and column family
@@ -1165,7 +1165,7 @@ func (db *DB) NewIterators(opts *ReadOptions, cfs []*ColumnFamilyHandle) (iters 
 		if err = fromCError(cErr); err == nil {
 			iters = make([]*Iterator, n)
 			for i := range iters {
-				iters[i] = newNativeIterator(_iters[i])
+				iters[i] = newNativeIteratorWithTS(_iters[i], opts.timestamp)
 			}
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -1146,7 +1146,7 @@ func (db *DB) NewIterator(opts *ReadOptions) *Iterator {
 // that uses the ReadOptions given.
 func (db *DB) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator {
 	cIter := C.rocksdb_create_iterator_cf(db.c, opts.c, cf.c)
-	return newNativeIterator(cIter)
+	return newNativeIteratorWithTS(cIter, opts.timestamp)
 }
 
 // NewIterators returns iterators from a consistent database state across multiple

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/linxGnu/grocksdb
 
 go 1.17
 
+toolchain go1.23.6
+
 require github.com/stretchr/testify v1.10.0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/linxGnu/grocksdb
 
 go 1.17
 
-toolchain go1.23.6
-
 require github.com/stretchr/testify v1.10.0
 
 require (

--- a/iterator.go
+++ b/iterator.go
@@ -34,7 +34,7 @@ func newNativeIterator(c *C.rocksdb_iterator_t) *Iterator {
 	return &Iterator{c: c}
 }
 
-// newNativeIteratorWithTS creates a Iterator object with ts.
+// newNativeIteratorWithTS creates a Iterator object with timestamp.
 func newNativeIteratorWithTS(c *C.rocksdb_iterator_t, ts []byte) *Iterator {
 	return &Iterator{c: c, timestamp: ts}
 }

--- a/iterator.go
+++ b/iterator.go
@@ -25,8 +25,11 @@ import (
 //	         return err
 //	     }
 type Iterator struct {
-	c         *C.rocksdb_iterator_t
-	timestamp []byte
+	c              *C.rocksdb_iterator_t
+	iterUpperBound []byte
+	iterLowerBound []byte
+	timestamp      []byte
+	timestampStart []byte
 }
 
 // NewNativeIterator creates a Iterator object.
@@ -34,9 +37,15 @@ func newNativeIterator(c *C.rocksdb_iterator_t) *Iterator {
 	return &Iterator{c: c}
 }
 
-// newNativeIteratorWithTS creates a Iterator object with timestamp.
-func newNativeIteratorWithTS(c *C.rocksdb_iterator_t, ts []byte) *Iterator {
-	return &Iterator{c: c, timestamp: ts}
+// newNativeIteratorWithReadOptions creates a Iterator object with ReadOptions.
+func newNativeIteratorWithReadOptions(c *C.rocksdb_iterator_t, opts *ReadOptions) *Iterator {
+	return &Iterator{
+		c:              c,
+		iterUpperBound: opts.iterUpperBound,
+		iterLowerBound: opts.iterLowerBound,
+		timestamp:      opts.timestamp,
+		timestampStart: opts.timestampStart,
+	}
 }
 
 // Valid returns false only when an Iterator has iterated past either the

--- a/iterator.go
+++ b/iterator.go
@@ -25,11 +25,8 @@ import (
 //	         return err
 //	     }
 type Iterator struct {
-	c              *C.rocksdb_iterator_t
-	iterUpperBound []byte
-	iterLowerBound []byte
-	timestamp      []byte
-	timestampStart []byte
+	c    *C.rocksdb_iterator_t
+	opts *ReadOptions
 }
 
 // NewNativeIterator creates a Iterator object.
@@ -40,11 +37,8 @@ func newNativeIterator(c *C.rocksdb_iterator_t) *Iterator {
 // newNativeIteratorWithReadOptions creates a Iterator object with ReadOptions.
 func newNativeIteratorWithReadOptions(c *C.rocksdb_iterator_t, opts *ReadOptions) *Iterator {
 	return &Iterator{
-		c:              c,
-		iterUpperBound: opts.iterUpperBound,
-		iterLowerBound: opts.iterLowerBound,
-		timestamp:      opts.timestamp,
-		timestampStart: opts.timestampStart,
+		c:    c,
+		opts: opts,
 	}
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -25,12 +25,18 @@ import (
 //	         return err
 //	     }
 type Iterator struct {
-	c *C.rocksdb_iterator_t
+	c         *C.rocksdb_iterator_t
+	timestamp []byte
 }
 
 // NewNativeIterator creates a Iterator object.
 func newNativeIterator(c *C.rocksdb_iterator_t) *Iterator {
 	return &Iterator{c: c}
+}
+
+// newNativeIteratorWithTS creates a Iterator object with ts.
+func newNativeIteratorWithTS(c *C.rocksdb_iterator_t, ts []byte) *Iterator {
+	return &Iterator{c: c, timestamp: ts}
 }
 
 // Valid returns false only when an Iterator has iterated past either the

--- a/transaction.go
+++ b/transaction.go
@@ -395,7 +395,7 @@ func (transaction *Transaction) DeleteCF(cf *ColumnFamilyHandle, key []byte) (er
 //
 // Caller is responsible for deleting the returned Iterator.
 func (transaction *Transaction) NewIterator(opts *ReadOptions) *Iterator {
-	return newNativeIterator(C.rocksdb_transaction_create_iterator(transaction.c, opts.c))
+	return newNativeIteratorWithTS(C.rocksdb_transaction_create_iterator(transaction.c, opts.c), opts.timestamp)
 }
 
 // NewIteratorCF returns an iterator that will iterate on all keys in the specific
@@ -409,7 +409,7 @@ func (transaction *Transaction) NewIterator(opts *ReadOptions) *Iterator {
 //
 // Caller is responsible for deleting the returned Iterator.
 func (transaction *Transaction) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator {
-	return newNativeIterator(C.rocksdb_transaction_create_iterator_cf(transaction.c, opts.c, cf.c))
+	return newNativeIteratorWithTS(C.rocksdb_transaction_create_iterator_cf(transaction.c, opts.c, cf.c), opts.timestamp)
 }
 
 // SetSavePoint records the state of the transaction for future calls to

--- a/transaction.go
+++ b/transaction.go
@@ -395,7 +395,7 @@ func (transaction *Transaction) DeleteCF(cf *ColumnFamilyHandle, key []byte) (er
 //
 // Caller is responsible for deleting the returned Iterator.
 func (transaction *Transaction) NewIterator(opts *ReadOptions) *Iterator {
-	return newNativeIteratorWithTS(C.rocksdb_transaction_create_iterator(transaction.c, opts.c), opts.timestamp)
+	return newNativeIteratorWithReadOptions(C.rocksdb_transaction_create_iterator(transaction.c, opts.c), opts)
 }
 
 // NewIteratorCF returns an iterator that will iterate on all keys in the specific
@@ -409,7 +409,7 @@ func (transaction *Transaction) NewIterator(opts *ReadOptions) *Iterator {
 //
 // Caller is responsible for deleting the returned Iterator.
 func (transaction *Transaction) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator {
-	return newNativeIteratorWithTS(C.rocksdb_transaction_create_iterator_cf(transaction.c, opts.c, cf.c), opts.timestamp)
+	return newNativeIteratorWithReadOptions(C.rocksdb_transaction_create_iterator_cf(transaction.c, opts.c, cf.c), opts)
 }
 
 // SetSavePoint records the state of the transaction for future calls to

--- a/transactiondb.go
+++ b/transactiondb.go
@@ -503,14 +503,14 @@ func (db *TransactionDB) FlushWAL(sync bool) (err error) {
 // ReadOptions given.
 func (db *TransactionDB) NewIterator(opts *ReadOptions) *Iterator {
 	cIter := C.rocksdb_transactiondb_create_iterator(db.c, opts.c)
-	return newNativeIteratorWithTS(cIter, opts.timestamp)
+	return newNativeIteratorWithReadOptions(cIter, opts)
 }
 
 // NewIteratorCF returns an Iterator over the the database and column family
 // that uses the ReadOptions given.
 func (db *TransactionDB) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator {
 	cIter := C.rocksdb_transactiondb_create_iterator_cf(db.c, opts.c, cf.c)
-	return newNativeIteratorWithTS(cIter, opts.timestamp)
+	return newNativeIteratorWithReadOptions(cIter, opts)
 }
 
 // Close closes the database.

--- a/transactiondb.go
+++ b/transactiondb.go
@@ -503,14 +503,14 @@ func (db *TransactionDB) FlushWAL(sync bool) (err error) {
 // ReadOptions given.
 func (db *TransactionDB) NewIterator(opts *ReadOptions) *Iterator {
 	cIter := C.rocksdb_transactiondb_create_iterator(db.c, opts.c)
-	return newNativeIterator(cIter)
+	return newNativeIteratorWithTS(cIter, opts.timestamp)
 }
 
 // NewIteratorCF returns an Iterator over the the database and column family
 // that uses the ReadOptions given.
 func (db *TransactionDB) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator {
 	cIter := C.rocksdb_transactiondb_create_iterator_cf(db.c, opts.c, cf.c)
-	return newNativeIterator(cIter)
+	return newNativeIteratorWithTS(cIter, opts.timestamp)
 }
 
 // Close closes the database.


### PR DESCRIPTION
avoid the reference of bytes properties in ReadOptions being accidentally released (mainly due to missing call of Destroy) after creating iterator