### PR TITLE
Don't eagerly remove golang gc references in Destroy

### DIFF
--- a/options.go
+++ b/options.go
@@ -2781,8 +2781,6 @@ func (opts *Options) Destroy() {
 		C.rocksdb_env_destroy(opts.env)
 		opts.env = nil
 	}
-
-	opts.bbto = nil
 }
 
 type LatestOptions struct {

--- a/options_backup.go
+++ b/options_backup.go
@@ -272,4 +272,5 @@ func (b *BackupEngineOptions) GetShareFilesWithChecksumNaming() ShareFilesNaming
 // Destroy releases these options.
 func (b *BackupEngineOptions) Destroy() {
 	C.rocksdb_backup_engine_options_destroy(b.c)
+	b.c = nil
 }

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -100,8 +100,6 @@ func newNativeBlockBasedTableOptions(c *C.rocksdb_block_based_table_options_t) *
 func (opts *BlockBasedTableOptions) Destroy() {
 	C.rocksdb_block_based_options_destroy(opts.c)
 	opts.c = nil
-	opts.cache = nil
-	opts.compCache = nil
 }
 
 // SetChecksum sets checksum types.

--- a/options_read.go
+++ b/options_read.go
@@ -322,10 +322,6 @@ func (opts *ReadOptions) GetIOTimeout() uint64 {
 func (opts *ReadOptions) Destroy() {
 	C.rocksdb_readoptions_destroy(opts.c)
 	opts.c = nil
-	opts.iterUpperBound = nil
-	opts.iterLowerBound = nil
-	opts.timestamp = nil
-	opts.timestampStart = nil
 }
 
 // SetTimestamp sets timestamp. Read should return the latest data visible to the


### PR DESCRIPTION
1. it's not necessary with golang gc.
2. user may want to keep reference it indirectly

ref: #172