### PR TITLE
Add BatchedMultiGetCF

### DIFF
--- a/array.go
+++ b/array.go
@@ -10,9 +10,10 @@ import (
 )
 
 type (
-	charsSlice        []*C.char
-	sizeTSlice        []C.size_t
-	columnFamilySlice []*C.rocksdb_column_family_handle_t
+	charsSlice         []*C.char
+	sizeTSlice         []C.size_t
+	columnFamilySlice  []*C.rocksdb_column_family_handle_t
+	pinnableSliceSlice []*C.rocksdb_pinnableslice_t
 )
 
 func (s charsSlice) c() **C.char {
@@ -28,6 +29,11 @@ func (s sizeTSlice) c() *C.size_t {
 func (s columnFamilySlice) c() **C.rocksdb_column_family_handle_t {
 	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
 	return (**C.rocksdb_column_family_handle_t)(unsafe.Pointer(sH.Data))
+}
+
+func (s pinnableSliceSlice) c() **C.rocksdb_pinnableslice_t {
+	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	return (**C.rocksdb_pinnableslice_t)(unsafe.Pointer(sH.Data))
 }
 
 // bytesSliceToCSlices converts a slice of byte slices to two slices with C

--- a/slice.go
+++ b/slice.go
@@ -56,6 +56,14 @@ func (s *Slice) Free() {
 	}
 }
 
+type PinnableSlices []*PinnableSliceHandle
+
+func (s PinnableSlices) Destroy() {
+	for _, s := range s {
+		s.Destroy()
+	}
+}
+
 // PinnableSliceHandle represents a handle to a PinnableSlice.
 type PinnableSliceHandle struct {
 	c *C.rocksdb_pinnableslice_t


### PR DESCRIPTION
added support for MultiGet API, which improves performance through batch execution of operations