### PR TITLE
add rocksdb_sstfilewriter_create_with_column_family_handle

### DIFF
--- a/c.h
+++ b/c.h
@@ -2305,6 +2305,10 @@ extern ROCKSDB_LIBRARY_API rocksdb_sstfilewriter_t*
 rocksdb_sstfilewriter_create_with_comparator(
     const rocksdb_envoptions_t* env, const rocksdb_options_t* io_options,
     const rocksdb_comparator_t* comparator);
+extern ROCKSDB_LIBRARY_API rocksdb_sstfilewriter_t*
+rocksdb_sstfilewriter_create_with_column_family_handle(
+    const rocksdb_envoptions_t *env, const rocksdb_options_t *io_options,
+    const rocksdb_column_family_handle_t *handle);
 extern ROCKSDB_LIBRARY_API void rocksdb_sstfilewriter_open(
     rocksdb_sstfilewriter_t* writer, const char* name, char** errptr);
 extern ROCKSDB_LIBRARY_API void rocksdb_sstfilewriter_add(

--- a/sst_file_writer.go
+++ b/sst_file_writer.go
@@ -33,6 +33,19 @@ func NewSSTFileWriterWithNativeComparator(opts *EnvOptions, dbOpts *Options, cmp
 	return &SSTFileWriter{c: c}
 }
 
+// NewSSTFileWriterWithCFHandle creates an SSTFileWriter object with column family handle.
+func NewSSTFileWriterWithCFHandle(opts *EnvOptions, dbOpts *Options, cfh *ColumnFamilyHandle) *SSTFileWriter {
+	cfh_ := unsafe.Pointer(cfh.c)
+	return NewSSTFileWriterWithNativeCFHandle(opts, dbOpts, cfh_)
+}
+
+// NewSSTFileWriterWithNativeCFHandle creates an SSTFileWriter object with native column family handle.
+func NewSSTFileWriterWithNativeCFHandle(opts *EnvOptions, dbOpts *Options, cfh unsafe.Pointer) *SSTFileWriter {
+	cfh_ := (*C.rocksdb_column_family_handle_t)(cfh)
+	c := C.rocksdb_sstfilewriter_create_with_column_family_handle(opts.c, dbOpts.c, cfh_)
+	return &SSTFileWriter{c: c}
+}
+
 // Open prepares SstFileWriter to write into file located at "path".
 func (w *SSTFileWriter) Open(path string) (err error) {
 	var (


### PR DESCRIPTION
allow to create a sstfilewriter with CF handler to pass CF information
@linxGnu please take a look