### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/linxGnu/grocksdb/security/code-scanning/1](https://github.com/linxGnu/grocksdb/security/code-scanning/1)

The fix for this issue is to add a `permissions` block to the workflow file, specifying only the minimal privileges necessary for the workflow to function correctly. For a typical Go CI workflow that checks out code, fetches dependencies, runs tests, and posts coverage to Coveralls, the default permission required is `contents: read`, unless any step actually writes to the repository, issues, or pull requests (e.g., commenting on PRs). Coveralls can comment on pull requests if so configured, but if not, only `contents: read` is generally sufficient. The best approach is to add `permissions: contents: read` at the workflow root (just after `name: CI`), which will apply to all jobs unless further permissions are specified for particular jobs. If analysis of the workflow finds that it needs additional permissions (e.g., for commenting on PRs), you can extend the block or add more granular permissions to the relevant job. For now, add the minimal configuration at the root of `.github/workflows/go.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
