### PR TITLE
Adapt RocksDB 11.1.1 & Add Windows MSYS2 workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -20,16 +21,16 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ^1.17
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Cache prebuilt static libs
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: cache-prebuilt-static-libs
         continue-on-error: false
         with:
@@ -50,13 +51,85 @@ jobs:
         run: go test -v -tags testing -count=1 -coverprofile=coverage.out
 
       - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.9
+        uses: jandelgado/gcov2lcov-action@v1.2.0
         with:
           infile: coverage.out
           outfile: coverage.lcov
 
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          path-to-lcov: coverage.lcov
+          file: coverage.lcov
+
+  build-windows:
+    name: CI (Windows)
+
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ^1.17
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v5
+
+      - name: Set up MSYS2 UCRT64 toolchain
+        uses: msys2/setup-msys2@v2
+        id: msys2
+        with:
+          msystem: UCRT64
+          update: true
+          # NOTE: do not pin `location` to C:\ — the windows runner ships a
+          # preinstalled MSYS2 at C:\msys64 and the action refuses to overwrite
+          # it. Let the action install to its default root and tell the build
+          # scripts where that is via $env:UCRT64 below.
+          install: >-
+            base-devel
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            git
+            mingw-w64-ucrt-x86_64-lz4
+            mingw-w64-ucrt-x86_64-zstd
+            mingw-w64-ucrt-x86_64-zlib
+            mingw-w64-ucrt-x86_64-snappy
+            mingw-w64-ucrt-x86_64-bzip2
+
+      - name: Add UCRT64 to PATH
+        # ${{ steps.msys2.outputs.msys2-location }} is the MSYS2 install root the
+        # action actually used (default location, not necessarily C:\msys64).
+        run: Add-Content $env:GITHUB_PATH "${{ steps.msys2.outputs.msys2-location }}\ucrt64\bin"
+
+      - name: Cache prebuilt static RocksDB
+        uses: actions/cache@v5
+        id: cache-rocksdb-windows
+        continue-on-error: false
+        with:
+          path: |
+            deps/
+          key: ${{ runner.os }}-${{ runner.arch }}-rocksdb-${{ hashFiles('build-deps.ps1') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-rocksdb-
+
+      - name: Build RocksDB static lib
+        if: steps.cache-rocksdb-windows.outputs.cache-hit != 'true'
+        env:
+          # Point the build scripts at the MSYS2 UCRT64 root the action installed
+          # (default location), instead of their hardcoded C:\msys64\ucrt64 default.
+          UCRT64: ${{ steps.msys2.outputs.msys2-location }}\ucrt64
+        run: .\build-deps.ps1
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Build & test grocksdb
+        env:
+          UCRT64: ${{ steps.msys2.outputs.msys2-location }}\ucrt64
+        run: .\build-grocksdb.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/*
 .vscode/c_cpp_properties.json
 dist
 .vscode/settings.json
+deps/

--- a/CHANGES-v11.1.1-features.md
+++ b/CHANGES-v11.1.1-features.md
@@ -1,0 +1,106 @@
+# grocksdb — New feature wrappers for RocksDB v10.10.1 → v11.1.1
+
+This document records the **Go-level wrappers added** for RocksDB C API surface that
+landed between RocksDB **v10.10.1** and **v11.1.1**.
+
+## Context
+
+grocksdb is a thin **CGO** binding over RocksDB's C API (`c.h`). The vendored
+repo-root `c.h` had already been synced to v11.1.1, so most of the new C symbols were
+**declared but not wrapped** in Go. A reviewer pointed out that the upgrade PR was
+missing useful wrappers (their example: `rocksdb_block_based_options_set_index_block_search_type`).
+
+This change adds idiomatic Go wrappers for the new, usefully-wrappable C API,
+following grocksdb's existing patterns (enum/bool setters, native-handle factories
+with `Destroy()`, and `//export` + `COWList` cgo callbacks).
+
+## What was added
+
+### 1. Block-based table options — `options_block_based_table.go`
+
+| Go API | C symbol |
+|--------|----------|
+| `IndexBlockSearchType` enum (`KBinarySearchIndexBlockSearchType`, `KInterpolationSearchIndexBlockSearchType`) | enum `rocksdb_block_based_table_index_block_search_type_*` |
+| `(*BlockBasedTableOptions) SetIndexBlockSearchType(IndexBlockSearchType)` | `rocksdb_block_based_options_set_index_block_search_type` |
+| `(*BlockBasedTableOptions) SetSeparateKeyValueInDataBlock(bool)` | `rocksdb_block_based_options_set_separate_key_value_in_data_block` |
+| `(*BlockBasedTableOptions) SetBlockAlign(bool)` | `rocksdb_block_based_options_set_block_align` |
+
+### 2. FIFO compaction options — `options_compaction.go`
+
+| Go API | C symbol |
+|--------|----------|
+| `(*FIFOCompactionOptions) Set/GetMaxDataFilesSize(uint64)` | `rocksdb_fifo_compaction_options_{set,get}_max_data_files_size` |
+| `(*FIFOCompactionOptions) SetUseKVRatioCompaction(bool)` / `UseKVRatioCompaction() bool` | `rocksdb_fifo_compaction_options_{set,get}_use_kv_ratio_compaction` |
+
+### 3. DB-level options & factories — `options.go`, `file_checksum.go`, `sst_partitioner.go`
+
+| Go API | C symbol |
+|--------|----------|
+| `(*Options) SetOpenFilesAsync(bool)` / `OpenFilesAsync() bool` | `rocksdb_options_{set,get}_open_files_async` |
+| `NewCRC32CFileChecksumGenFactory()` + `(*FileChecksumGenFactory) Destroy()` | `rocksdb_file_checksum_gen_crc32c_factory_create` / `..._factory_destroy` |
+| `(*Options) SetFileChecksumGenFactory(*FileChecksumGenFactory)` | `rocksdb_options_set_file_checksum_gen_factory` |
+| `NewFixedPrefixSSTPartitionerFactory(uint)` + `(*SSTPartitionerFactory) Destroy()` | `rocksdb_sst_partitioner_fixed_prefix_factory_create` / `..._factory_destroy` |
+| `(*Options) SetSSTPartitionerFactory(*SSTPartitionerFactory)` | `rocksdb_options_set_sst_partitioner_factory` |
+
+> **Ownership:** `SetFileChecksumGenFactory` / `SetSSTPartitionerFactory` take
+> ownership of the factory's native handle. The `Options` frees it on `Destroy()`;
+> callers should **not** also call `Destroy()` on the passed factory. New
+> `Options` struct fields `cfcg` / `cspf` hold the handles and are freed in
+> `(*Options).Destroy()`.
+
+### 4. Callback logger — `logger.go`, `grocksdb.h`, `grocksdb.c`
+
+| Go API | C symbol |
+|--------|----------|
+| `LogHandler` type `func(level InfoLogLevel, msg string)` | — |
+| `NewCallbackLogger(InfoLogLevel, LogHandler) *Logger` | `rocksdb_logger_create_callback_logger` (via `gorocksdb_logger_create_callback` shim) |
+
+Implemented with the comparator-style cgo pattern: a `COWList` registry holds the
+handler, the registry index is passed as the callback's `priv`, and
+`//export gorocksdb_logger_log` forwards each message back to Go. Reuses the existing
+`(*Logger).Destroy()` and `(*Options).SetInfoLog`.
+
+### 5. WriteBatch lazy-data iteration — `write_batch.go`, `grocksdb.h`, `grocksdb.c`
+
+| Go API | C symbol |
+|--------|----------|
+| `WriteBatchHandler` interface (`Put`, `Delete`, `LogData`, `PutCF`, `DeleteCF`, `MergeCF`) | — |
+| `(*WriteBatch) Iterate(WriteBatchHandler)` | `rocksdb_writebatch_iterate_ld` (via `gorocksdb_writebatch_iterate_ld`) |
+| `(*WriteBatch) IterateCF(WriteBatchHandler)` | `rocksdb_writebatch_iterate_cf_ld` (via `gorocksdb_writebatch_iterate_cf_ld`) |
+
+The `_ld` (lazy-data) variants add a `log_data` callback over the existing
+iterate/iterate_cf signatures and handle large values. A `COWList` registry plus six
+`//export` callbacks (`gorocksdb_writebatch_put`, `_deleted`, `_logdata`, `_put_cf`,
+`_deleted_cf`, `_merge_cf`) bridge to the handler. The existing pure-Go
+`(*WriteBatch) NewIterator()` is left unchanged for backward compatibility.
+
+## Files changed
+
+**Modified:** `options_block_based_table.go`, `options_compaction.go`, `options.go`,
+`logger.go`, `write_batch.go`, `grocksdb.h`, `grocksdb.c`.
+
+**Added:** `file_checksum.go`, `sst_partitioner.go`.
+
+**Tests:** extended `options_block_based_table_test.go`, `options_compaction_test.go`,
+`options_test.go` (`TestOptionsOpenFilesAsyncAndFactories`),
+`write_batch_test.go` (`TestWriteBatchIterateLD`); added `logger_test.go`
+(`TestCallbackLogger`).
+
+## Intentionally out of scope
+
+| Feature | Reason |
+|---------|--------|
+| `rocksdb_abort_all_compactions` / `rocksdb_resume_all_compactions` | Not present in the vendored `c.h` yet; would require a `c.h` edit first. |
+| `rocksdb_table_properties_collector_factory_*` | `c.h` exposes only `_destroy` and `_add` — there is **no C constructor**, so nothing can be created to add. |
+| `rocksdb_compaction_service_options_override_*` (~17 fns) | Large, advanced remote-compaction surface; deferred. |
+
+## Validation
+
+- `gofmt` clean on all changed/added files.
+- cgo cross-check: the 7 `//export` Go callbacks match the 7 C trampoline call sites.
+- Pending (requires the cgo toolchain + linked RocksDB v11.1.1):
+  ```
+  go build ./...
+  go vet ./...
+  go test -run 'TestBBT|TestFifoCompactOption|TestOptions|CallbackLogger|WriteBatchIterateLD' ./...
+  ```

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Almost C API, excepts:
 - [ ] transactiondb_property_value/transactiondb_property_int
 - [ ] optimistictransactiondb_property_value/optimistictransactiondb_property_int
 - [ ] writebatch_update_timestamps/writebatch_wi_update_timestamps/writebatch_iterate_cf
+- [ ] writebatch_iterate_ld/writebatch_iterate_cf_ld
 - [ ] approximate_sizes_cf_with_flags
 - [ ] logger_create_callback_logger
 - [ ] get_into_buffer/get_into_buffer_cf
@@ -87,4 +88,13 @@ Almost C API, excepts:
   - [ ] onbackground_error_cb
 - [ ] compactionservice
 - [ ] rocksdb_open_and_compact*
+- [ ] file_checksum_gen_factory (crc32c factory/set_file_checksum_gen_factory)
+- [ ] sst_partitioner_factory (fixed_prefix factory/set_sst_partitioner_factory)
+- [ ] table_properties_collector_factory (add_table_properties_collector_factory)
+- [ ] block_based_options_set_separate_key_value_in_data_block
+- [ ] block_based_options_set_index_block_search_type
+- [ ] block_based_options_set_block_align
+- [ ] options_set_open_files_async/options_get_open_files_async
+- [ ] fifo_compaction_options_set_max_data_files_size/get_max_data_files_size
+- [ ] fifo_compaction_options_set_use_kv_ratio_compaction/get_use_kv_ratio_compaction
 

--- a/build-deps.ps1
+++ b/build-deps.ps1
@@ -21,23 +21,35 @@ $ErrorActionPreference = 'Stop'
 $RocksDbTag = 'v11.1.1'
 
 # --- Toolchain locations (MSYS2 UCRT64) ---
-# Default to the standard MSYS2 install root. Allow an override via $env:UCRT64
-# for environments where MSYS2 lives elsewhere (e.g. CI runners). If the override
-# is unset and the default path is missing, fall back to discovering gcc on PATH
-# (msys2/setup-msys2 adds C:\msys64\ucrt64\bin to PATH) and derive the root from it.
-if ($env:UCRT64) {
-    $Ucrt64 = $env:UCRT64
-} elseif (Test-Path 'C:\msys64\ucrt64') {
-    $Ucrt64 = 'C:\msys64\ucrt64'
-} else {
-    $gccOnPath = Get-Command gcc.exe -ErrorAction SilentlyContinue
-    if ($gccOnPath) {
-        # <ucrt64>\bin\gcc.exe -> <ucrt64>
-        $Ucrt64 = Split-Path -Parent (Split-Path -Parent $gccOnPath.Source)
-    } else {
-        $Ucrt64 = 'C:\msys64\ucrt64'  # keep default so the error message is actionable
+# Detection order:
+#   1. $env:UCRT64      — explicit override (e.g. CI runners / msys2/setup-msys2)
+#   2. $env:MSYS2_ROOT  — MSYS2 install root; UCRT64 lives at <root>\ucrt64
+#   3. C:\msys64        — standard MSYS2 install root
+#   4. Registry         — MSYS2 installer uninstall entry (InstallLocation)
+function Find-Ucrt64 {
+    if ($env:UCRT64) { return $env:UCRT64 }
+    if ($env:MSYS2_ROOT) {
+        $candidate = Join-Path $env:MSYS2_ROOT 'ucrt64'
+        if (Test-Path $candidate) { return $candidate }
     }
+    if (Test-Path 'C:\msys64\ucrt64') { return 'C:\msys64\ucrt64' }
+    $uninstallKeys = @(
+        'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+    foreach ($keyPath in $uninstallKeys) {
+        $entry = Get-ItemProperty -Path $keyPath -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -like 'MSYS2*' -and $_.InstallLocation } |
+            Select-Object -First 1
+        if ($entry) {
+            $candidate = Join-Path $entry.InstallLocation 'ucrt64'
+            if (Test-Path $candidate) { return $candidate }
+        }
+    }
+    return 'C:\msys64\ucrt64'  # keep default so the error message is actionable
 }
+$Ucrt64 = Find-Ucrt64
 $Gcc    = Join-Path $Ucrt64 'bin\gcc.exe'
 $Gpp    = Join-Path $Ucrt64 'bin\g++.exe'
 $Cmake  = Join-Path $Ucrt64 'bin\cmake.exe'

--- a/build-deps.ps1
+++ b/build-deps.ps1
@@ -2,7 +2,7 @@
 <#
   build-deps.ps1 — clone & statically build RocksDB into ./deps
 
-  Builds RocksDB v10.10.1 as a static library (librocksdb.a) using the MSYS2
+  Builds RocksDB v11.1.1 as a static library (librocksdb.a) using the MSYS2
   UCRT64 GCC toolchain + CMake + Ninja, so that grocksdb can link against it.
 
   Run from the grocksdb repo root:
@@ -15,10 +15,10 @@
 $ErrorActionPreference = 'Stop'
 
 # --- Version ---
-# grocksdb (this repo) targets the RocksDB 10.10.1 C API. Build the matching tag so
-# the CGO wrappers in c.h / grocksdb.c link cleanly. Newer RocksDB (11.x) changes the
-# C API and will NOT link against this binding.
-$RocksDbTag = 'v10.10.1'
+# grocksdb (this repo) targets the RocksDB 11.1.1 C API. Build the matching tag so
+# the CGO wrappers in c.h / grocksdb.c link cleanly. Using a different RocksDB minor
+# version may add/remove C API symbols and fail to link against this binding.
+$RocksDbTag = 'v11.1.1'
 
 # --- Toolchain locations (MSYS2 UCRT64) ---
 $Ucrt64 = 'C:\msys64\ucrt64'

--- a/build-deps.ps1
+++ b/build-deps.ps1
@@ -21,7 +21,23 @@ $ErrorActionPreference = 'Stop'
 $RocksDbTag = 'v11.1.1'
 
 # --- Toolchain locations (MSYS2 UCRT64) ---
-$Ucrt64 = 'C:\msys64\ucrt64'
+# Default to the standard MSYS2 install root. Allow an override via $env:UCRT64
+# for environments where MSYS2 lives elsewhere (e.g. CI runners). If the override
+# is unset and the default path is missing, fall back to discovering gcc on PATH
+# (msys2/setup-msys2 adds C:\msys64\ucrt64\bin to PATH) and derive the root from it.
+if ($env:UCRT64) {
+    $Ucrt64 = $env:UCRT64
+} elseif (Test-Path 'C:\msys64\ucrt64') {
+    $Ucrt64 = 'C:\msys64\ucrt64'
+} else {
+    $gccOnPath = Get-Command gcc.exe -ErrorAction SilentlyContinue
+    if ($gccOnPath) {
+        # <ucrt64>\bin\gcc.exe -> <ucrt64>
+        $Ucrt64 = Split-Path -Parent (Split-Path -Parent $gccOnPath.Source)
+    } else {
+        $Ucrt64 = 'C:\msys64\ucrt64'  # keep default so the error message is actionable
+    }
+}
 $Gcc    = Join-Path $Ucrt64 'bin\gcc.exe'
 $Gpp    = Join-Path $Ucrt64 'bin\g++.exe'
 $Cmake  = Join-Path $Ucrt64 'bin\cmake.exe'

--- a/build-deps.ps1
+++ b/build-deps.ps1
@@ -1,0 +1,124 @@
+#requires -Version 5.1
+<#
+  build-deps.ps1 — clone & statically build RocksDB into ./deps
+
+  Builds RocksDB v10.10.1 as a static library (librocksdb.a) using the MSYS2
+  UCRT64 GCC toolchain + CMake + Ninja, so that grocksdb can link against it.
+
+  Run from the grocksdb repo root:
+      .\build-deps.ps1
+
+  If PowerShell blocks the script (execution policy):
+      powershell -ExecutionPolicy Bypass -File .\build-deps.ps1
+#>
+
+$ErrorActionPreference = 'Stop'
+
+# --- Version ---
+# grocksdb (this repo) targets the RocksDB 10.10.1 C API. Build the matching tag so
+# the CGO wrappers in c.h / grocksdb.c link cleanly. Newer RocksDB (11.x) changes the
+# C API and will NOT link against this binding.
+$RocksDbTag = 'v10.10.1'
+
+# --- Toolchain locations (MSYS2 UCRT64) ---
+$Ucrt64 = 'C:\msys64\ucrt64'
+$Gcc    = Join-Path $Ucrt64 'bin\gcc.exe'
+$Gpp    = Join-Path $Ucrt64 'bin\g++.exe'
+$Cmake  = Join-Path $Ucrt64 'bin\cmake.exe'
+$Ninja  = Join-Path $Ucrt64 'bin\ninja.exe'
+
+# --- Paths ---
+$Root = $PSScriptRoot
+$Deps = Join-Path $Root 'deps'
+
+function Assert-Tool($path, $name) {
+    if (-not (Test-Path $path)) {
+        throw "$name not found at $path. Install the MSYS2 UCRT64 toolchain first (see win-build.md)."
+    }
+    Write-Host "  [ok] $name -> $path"
+}
+
+# ---------------------------------------------------------------------------
+# Check toolchain
+# ---------------------------------------------------------------------------
+Write-Host '== Checking UCRT64 toolchain =='
+if (-not (Test-Path $Ucrt64)) {
+    throw "UCRT64 not found at $Ucrt64. Install MSYS2 and the UCRT64 toolchain first."
+}
+Assert-Tool $Gcc   'gcc'
+Assert-Tool $Gpp   'g++'
+Assert-Tool $Cmake 'cmake'
+Assert-Tool $Ninja 'ninja'
+
+# Put UCRT64 bin first on PATH for this process (gcc, g++, cmake, ninja, and the
+# static compression archives' tooling). Set CC/CXX so CMake picks GCC, not MSVC.
+$env:PATH = "$Ucrt64\bin;$env:PATH"
+$env:CC   = $Gcc
+$env:CXX  = $Gpp
+
+# ---------------------------------------------------------------------------
+# Reset ./deps
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Host '== Resetting deps directory =='
+if (Test-Path $Deps) {
+    Write-Host "  removing existing $Deps"
+    Remove-Item -Recurse -Force $Deps
+}
+New-Item -ItemType Directory -Path $Deps | Out-Null
+Write-Host "  created $Deps"
+
+# ---------------------------------------------------------------------------
+# Clone RocksDB into ./deps/rocksdb
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Host "== Cloning RocksDB $RocksDbTag =="
+$RocksDbSrc = Join-Path $Deps 'rocksdb'
+git clone --depth 1 --branch $RocksDbTag https://github.com/facebook/rocksdb.git $RocksDbSrc
+if ($LASTEXITCODE -ne 0) { throw 'git clone rocksdb failed' }
+
+# ---------------------------------------------------------------------------
+# Build RocksDB (static, with compression libs)
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Host '== Building RocksDB (static) =='
+$RocksDbBuild = Join-Path $RocksDbSrc 'build'
+
+& $Cmake -S $RocksDbSrc -B $RocksDbBuild -G Ninja `
+    -DCMAKE_BUILD_TYPE=Release `
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" `
+    -DCMAKE_C_COMPILER="$Ucrt64/bin/gcc.exe" `
+    -DCMAKE_CXX_COMPILER="$Ucrt64/bin/g++.exe" `
+    -DROCKSDB_BUILD_SHARED=OFF `
+    -DWITH_GFLAGS=OFF `
+    -DWITH_TESTS=OFF `
+    -DWITH_BENCHMARK_TOOLS=OFF `
+    -DWITH_TOOLS=OFF `
+    -DWITH_CORE_TOOLS=OFF `
+    -DWITH_TRACE_TOOLS=OFF `
+    -DWITH_LZ4=ON `
+    -DWITH_ZSTD=ON `
+    -DWITH_ZLIB=ON `
+    -DWITH_SNAPPY=ON `
+    -DWITH_BZ2=ON `
+    -DWITH_LIBURING=OFF `
+    -DPORTABLE=ON `
+    -DFAIL_ON_WARNINGS=OFF
+if ($LASTEXITCODE -ne 0) { throw 'rocksdb cmake configure failed' }
+
+& $Cmake --build $RocksDbBuild --config Release --target rocksdb
+if ($LASTEXITCODE -ne 0) { throw 'rocksdb build failed' }
+
+# Copy the archive next to include/ so CGO link paths are simple
+# (-L deps/rocksdb -I deps/rocksdb/include).
+Copy-Item (Join-Path $RocksDbBuild 'librocksdb.a') (Join-Path $RocksDbSrc 'librocksdb.a') -Force
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Host '== Done =='
+Write-Host "  rocksdb lib: $RocksDbSrc\librocksdb.a"
+Write-Host "  rocksdb inc: $RocksDbSrc\include"
+Write-Host ''
+Write-Host 'Next: build & test grocksdb with  .\build-grocksdb.ps1'

--- a/build-grocksdb.ps1
+++ b/build-grocksdb.ps1
@@ -21,22 +21,35 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # --- Toolchain (UCRT64 GCC) ---
-# Default to the standard MSYS2 install root. Allow an override via $env:UCRT64
-# for environments where MSYS2 lives elsewhere (e.g. CI runners). If the override
-# is unset and the default path is missing, discover gcc on PATH and derive the
-# root from it (msys2/setup-msys2 puts C:\msys64\ucrt64\bin on PATH).
-if ($env:UCRT64) {
-    $Ucrt64 = $env:UCRT64
-} elseif (Test-Path 'C:\msys64\ucrt64') {
-    $Ucrt64 = 'C:\msys64\ucrt64'
-} else {
-    $gccOnPath = Get-Command gcc.exe -ErrorAction SilentlyContinue
-    if ($gccOnPath) {
-        $Ucrt64 = Split-Path -Parent (Split-Path -Parent $gccOnPath.Source)
-    } else {
-        $Ucrt64 = 'C:\msys64\ucrt64'  # keep default so the error message is actionable
+# Detection order (same as build-deps.ps1):
+#   1. $env:UCRT64      — explicit override (e.g. CI runners / msys2/setup-msys2)
+#   2. $env:MSYS2_ROOT  — MSYS2 install root; UCRT64 lives at <root>\ucrt64
+#   3. C:\msys64        — standard MSYS2 install root
+#   4. Registry         — MSYS2 installer uninstall entry (InstallLocation)
+function Find-Ucrt64 {
+    if ($env:UCRT64) { return $env:UCRT64 }
+    if ($env:MSYS2_ROOT) {
+        $candidate = Join-Path $env:MSYS2_ROOT 'ucrt64'
+        if (Test-Path $candidate) { return $candidate }
     }
+    if (Test-Path 'C:\msys64\ucrt64') { return 'C:\msys64\ucrt64' }
+    $uninstallKeys = @(
+        'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+    foreach ($keyPath in $uninstallKeys) {
+        $entry = Get-ItemProperty -Path $keyPath -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -like 'MSYS2*' -and $_.InstallLocation } |
+            Select-Object -First 1
+        if ($entry) {
+            $candidate = Join-Path $entry.InstallLocation 'ucrt64'
+            if (Test-Path $candidate) { return $candidate }
+        }
+    }
+    return 'C:\msys64\ucrt64'  # keep default so the error message is actionable
 }
+$Ucrt64 = Find-Ucrt64
 $Gcc    = Join-Path $Ucrt64 'bin\gcc.exe'
 $Gpp    = Join-Path $Ucrt64 'bin\g++.exe'
 

--- a/build-grocksdb.ps1
+++ b/build-grocksdb.ps1
@@ -21,7 +21,22 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # --- Toolchain (UCRT64 GCC) ---
-$Ucrt64 = 'C:\msys64\ucrt64'
+# Default to the standard MSYS2 install root. Allow an override via $env:UCRT64
+# for environments where MSYS2 lives elsewhere (e.g. CI runners). If the override
+# is unset and the default path is missing, discover gcc on PATH and derive the
+# root from it (msys2/setup-msys2 puts C:\msys64\ucrt64\bin on PATH).
+if ($env:UCRT64) {
+    $Ucrt64 = $env:UCRT64
+} elseif (Test-Path 'C:\msys64\ucrt64') {
+    $Ucrt64 = 'C:\msys64\ucrt64'
+} else {
+    $gccOnPath = Get-Command gcc.exe -ErrorAction SilentlyContinue
+    if ($gccOnPath) {
+        $Ucrt64 = Split-Path -Parent (Split-Path -Parent $gccOnPath.Source)
+    } else {
+        $Ucrt64 = 'C:\msys64\ucrt64'  # keep default so the error message is actionable
+    }
+}
 $Gcc    = Join-Path $Ucrt64 'bin\gcc.exe'
 $Gpp    = Join-Path $Ucrt64 'bin\g++.exe'
 

--- a/build-grocksdb.ps1
+++ b/build-grocksdb.ps1
@@ -1,0 +1,107 @@
+#requires -Version 5.1
+<#
+  build-grocksdb.ps1 — build & test the grocksdb CGO binding against the static
+  RocksDB built by build-deps.ps1 into ./deps/rocksdb.
+
+  Uses the MSYS2 UCRT64 GCC toolchain and links statically against
+  deps/rocksdb/librocksdb.a plus the UCRT64 compression archives.
+
+  Run from the grocksdb repo root:
+      .\build-grocksdb.ps1            # compile (go build) + run tests (go test)
+      .\build-grocksdb.ps1 -NoTest    # compile only, skip tests
+
+  If PowerShell blocks the script (execution policy):
+      powershell -ExecutionPolicy Bypass -File .\build-grocksdb.ps1
+#>
+
+param(
+    [switch]$NoTest
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Toolchain (UCRT64 GCC) ---
+$Ucrt64 = 'C:\msys64\ucrt64'
+$Gcc    = Join-Path $Ucrt64 'bin\gcc.exe'
+$Gpp    = Join-Path $Ucrt64 'bin\g++.exe'
+
+# --- Locate the RocksDB dep built by build-deps.ps1 (./deps/rocksdb) ---
+$Repo    = $PSScriptRoot
+$Deps    = Join-Path $Repo 'deps'
+$RocksDb = Join-Path $Deps 'rocksdb'
+
+# --- Sanity checks ---
+if (-not (Test-Path $Gcc)) { throw "gcc not found at $Gcc. Install the MSYS2 UCRT64 toolchain (see win-build.md)." }
+if (-not (Test-Path $Gpp)) { throw "g++ not found at $Gpp. Install the MSYS2 UCRT64 toolchain (see win-build.md)." }
+if (-not (Test-Path (Join-Path $RocksDb 'librocksdb.a'))) {
+    throw "librocksdb.a missing under $RocksDb. Run .\build-deps.ps1 first."
+}
+if (-not (Test-Path (Join-Path $RocksDb 'include\rocksdb\c.h'))) {
+    throw "RocksDB C headers missing under $RocksDb\include. Run .\build-deps.ps1 first."
+}
+
+# --- Put UCRT64 bin first on PATH and set the CGO toolchain ---
+$env:PATH        = "$Ucrt64\bin;$env:PATH"
+$env:CGO_ENABLED = '1'
+$env:CC          = $Gcc
+$env:CXX         = $Gpp
+
+# --- Include paths: RocksDB headers ---
+$env:CGO_CFLAGS   = "-I$RocksDb\include"
+$env:CGO_CXXFLAGS = "-I$RocksDb\include"
+
+# --- Static link flags.
+#     We build with `-tags grocksdb_no_link` so grocksdb does NOT inject its own
+#     default LDFLAGS (which include `-ldl`, a POSIX-only lib that does not exist
+#     on Windows/mingw). We provide the full link line ourselves here.
+#
+#     Order matters with GCC static libs: the consumer (-lrocksdb) comes BEFORE the
+#     libraries it depends on (compression libs, then C++/runtime, then Windows
+#     system libs). -lbcrypt / -ldbghelp satisfy RocksDB's BCrypt*/SymInitialize
+#     references on recent Windows. ---
+$env:CGO_LDFLAGS = @(
+    "-L$RocksDb", "-L$Ucrt64\lib",
+    '-lrocksdb',
+    '-lzstd', '-llz4', '-lz', '-lsnappy', '-lbz2',
+    '-lstdc++', '-lm', '-lpthread',
+    '-lshlwapi', '-lrpcrt4', '-lbcrypt', '-ldbghelp',
+    '-static', '-static-libgcc', '-static-libstdc++'
+) -join ' '
+
+Write-Host '== grocksdb build environment =='
+Write-Host "  CC            = $env:CC"
+Write-Host "  CXX           = $env:CXX"
+Write-Host "  CGO_CFLAGS    = $env:CGO_CFLAGS"
+Write-Host "  CGO_LDFLAGS   = $env:CGO_LDFLAGS"
+Write-Host ''
+
+# --- Ensure module deps are present ---
+Write-Host '== go mod download =='
+go mod download
+if ($LASTEXITCODE -ne 0) { throw 'go mod download failed' }
+
+# ---------------------------------------------------------------------------
+# Compile the package (CGO). `grocksdb_no_link` => use our CGO_LDFLAGS only.
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Host '== Building grocksdb (go build) =='
+go build -v -tags grocksdb_no_link ./...
+if ($LASTEXITCODE -ne 0) { throw 'go build failed' }
+Write-Host '  [ok] grocksdb compiled'
+
+# ---------------------------------------------------------------------------
+# Run tests
+# ---------------------------------------------------------------------------
+if ($NoTest) {
+    Write-Host ''
+    Write-Host '== Skipping tests (-NoTest) =='
+} else {
+    Write-Host ''
+    Write-Host '== Running tests (go test) =='
+    go test -v -tags grocksdb_no_link -count=1 ./...
+    if ($LASTEXITCODE -ne 0) { throw 'go test failed' }
+    Write-Host '  [ok] tests passed'
+}
+
+Write-Host ''
+Write-Host '=== grocksdb built & tested against static RocksDB in .\deps\rocksdb ==='

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ cd $BUILD_PATH && wget https://github.com/facebook/zstd/archive/v${zstd_version}
 
 # Note: if you don't have a good reason, please do not set -DPORTABLE=ON
 # This one is set here on purpose of compatibility with github action runtime processor
-rocksdb_version="10.10.1"
+rocksdb_version="11.1.1"
 cd $BUILD_PATH && wget https://github.com/facebook/rocksdb/archive/v${rocksdb_version}.tar.gz && tar xzf v${rocksdb_version}.tar.gz && cd rocksdb-${rocksdb_version}/ && \
     mkdir -p build_place && cd build_place && cmake -DCMAKE_BUILD_TYPE=Release $CMAKE_REQUIRED_PARAMS -DCMAKE_PREFIX_PATH=$INSTALL_PREFIX -DWITH_TESTS=OFF -DWITH_GFLAGS=OFF \
     -DWITH_BENCHMARK_TOOLS=OFF -DWITH_TOOLS=OFF -DWITH_MD_LIBRARY=OFF -DWITH_RUNTIME_DEBUG=OFF -DROCKSDB_BUILD_SHARED=OFF -DWITH_SNAPPY=ON -DWITH_LZ4=ON -DWITH_ZLIB=ON -DWITH_LIBURING=OFF \

--- a/c.h
+++ b/c.h
@@ -86,6 +86,12 @@ typedef struct rocksdb_compactionfiltercontext_t
     rocksdb_compactionfiltercontext_t;
 typedef struct rocksdb_compactionfilterfactory_t
     rocksdb_compactionfilterfactory_t;
+typedef struct rocksdb_file_checksum_gen_factory_t
+    rocksdb_file_checksum_gen_factory_t;
+typedef struct rocksdb_sst_partitioner_factory_t
+    rocksdb_sst_partitioner_factory_t;
+typedef struct rocksdb_table_properties_collector_factory_t
+    rocksdb_table_properties_collector_factory_t;
 typedef struct rocksdb_comparator_t rocksdb_comparator_t;
 typedef struct rocksdb_dbpath_t rocksdb_dbpath_t;
 typedef struct rocksdb_env_t rocksdb_env_t;
@@ -944,6 +950,11 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate(
     rocksdb_writebatch_t*, void* state,
     void (*put)(void*, const char* k, size_t klen, const char* v, size_t vlen),
     void (*deleted)(void*, const char* k, size_t klen));
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate_ld(
+    rocksdb_writebatch_t*, void* state,
+    void (*put)(void*, const char* k, size_t klen, const char* v, size_t vlen),
+    void (*deleted)(void*, const char* k, size_t klen),
+    void (*log_data)(void*, const char* blob, size_t blob_len));
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate_cf(
     rocksdb_writebatch_t*, void* state,
     void (*put_cf)(void*, uint32_t cfid, const char* k, size_t klen,
@@ -951,6 +962,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate_cf(
     void (*deleted_cf)(void*, uint32_t cfid, const char* k, size_t klen),
     void (*merge_cf)(void*, uint32_t cfid, const char* k, size_t klen,
                      const char* v, size_t vlen));
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_iterate_cf_ld(
+    rocksdb_writebatch_t*, void* state,
+    void (*put_cf)(void*, uint32_t cfid, const char* k, size_t klen,
+                   const char* v, size_t vlen),
+    void (*deleted_cf)(void*, uint32_t cfid, const char* k, size_t klen),
+    void (*merge_cf)(void*, uint32_t cfid, const char* k, size_t klen,
+                     const char* v, size_t vlen),
+    void (*log_data)(void*, const char* blob, size_t blob_len));
 extern ROCKSDB_LIBRARY_API const char* rocksdb_writebatch_data(
     rocksdb_writebatch_t*, size_t* size);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_set_save_point(
@@ -1176,6 +1195,9 @@ rocksdb_block_based_options_set_whole_key_filtering(
     rocksdb_block_based_table_options_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API void rocksdb_block_based_options_set_format_version(
     rocksdb_block_based_table_options_t*, int);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_block_based_options_set_separate_key_value_in_data_block(
+    rocksdb_block_based_table_options_t*, unsigned char);
 enum {
   rocksdb_block_based_table_index_type_binary_search = 0,
   rocksdb_block_based_table_index_type_hash_search = 1,
@@ -1189,6 +1211,13 @@ enum {
 };
 extern ROCKSDB_LIBRARY_API void
 rocksdb_block_based_options_set_data_block_index_type(
+    rocksdb_block_based_table_options_t*, int);  // uses one of the above enums
+enum {
+  rocksdb_block_based_table_index_block_search_type_binary = 0,
+  rocksdb_block_based_table_index_block_search_type_interpolation = 1,
+};
+extern ROCKSDB_LIBRARY_API void
+rocksdb_block_based_options_set_index_block_search_type(
     rocksdb_block_based_table_options_t*, int);  // uses one of the above enums
 extern ROCKSDB_LIBRARY_API void
 rocksdb_block_based_options_set_data_block_hash_ratio(
@@ -1225,6 +1254,8 @@ rocksdb_block_based_options_set_partition_pinning_tier(
 extern ROCKSDB_LIBRARY_API void
 rocksdb_block_based_options_set_unpartitioned_pinning_tier(
     rocksdb_block_based_table_options_t*, int);
+extern ROCKSDB_LIBRARY_API void rocksdb_block_based_options_set_block_align(
+    rocksdb_block_based_table_options_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_write_buffer_manager(
     rocksdb_options_t* opt, rocksdb_write_buffer_manager_t* wbm);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_sst_file_manager(
@@ -1448,6 +1479,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_paranoid_checks(
     rocksdb_options_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_paranoid_checks(
     rocksdb_options_t*);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_open_files_async(
+    rocksdb_options_t*, unsigned char);
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_open_files_async(
+    rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_db_paths(
     rocksdb_options_t*, const rocksdb_dbpath_t** path_values, size_t num_paths);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_cf_paths(
@@ -1471,6 +1506,31 @@ rocksdb_logger_create_callback_logger(int log_level,
                                       void* priv);
 extern ROCKSDB_LIBRARY_API void rocksdb_logger_destroy(
     rocksdb_logger_t* logger);
+
+/* File Checksum Gen Factory */
+extern ROCKSDB_LIBRARY_API rocksdb_file_checksum_gen_factory_t*
+rocksdb_file_checksum_gen_crc32c_factory_create(void);
+extern ROCKSDB_LIBRARY_API void rocksdb_file_checksum_gen_factory_destroy(
+    rocksdb_file_checksum_gen_factory_t* factory);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_file_checksum_gen_factory(
+    rocksdb_options_t*, rocksdb_file_checksum_gen_factory_t*);
+
+/* SST Partitioner Factory */
+extern ROCKSDB_LIBRARY_API rocksdb_sst_partitioner_factory_t*
+rocksdb_sst_partitioner_fixed_prefix_factory_create(size_t prefix_len);
+extern ROCKSDB_LIBRARY_API void rocksdb_sst_partitioner_factory_destroy(
+    rocksdb_sst_partitioner_factory_t* factory);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_sst_partitioner_factory(
+    rocksdb_options_t*, rocksdb_sst_partitioner_factory_t*);
+
+/* Table Properties Collector Factory */
+extern ROCKSDB_LIBRARY_API void
+rocksdb_table_properties_collector_factory_destroy(
+    rocksdb_table_properties_collector_factory_t* factory);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_add_table_properties_collector_factory(
+    rocksdb_options_t*, rocksdb_table_properties_collector_factory_t*);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_write_buffer_size(
     rocksdb_options_t*, size_t);
 extern ROCKSDB_LIBRARY_API size_t
@@ -1615,13 +1675,6 @@ rocksdb_options_set_skip_stats_update_on_db_open(rocksdb_options_t* opt,
                                                  unsigned char val);
 extern ROCKSDB_LIBRARY_API unsigned char
 rocksdb_options_get_skip_stats_update_on_db_open(rocksdb_options_t* opt);
-extern ROCKSDB_LIBRARY_API void
-rocksdb_options_set_skip_checking_sst_file_sizes_on_db_open(
-    rocksdb_options_t* opt, unsigned char val);
-extern ROCKSDB_LIBRARY_API unsigned char
-rocksdb_options_get_skip_checking_sst_file_sizes_on_db_open(
-    rocksdb_options_t* opt);
-
 /* Blob Options Settings */
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_enable_blob_files(
     rocksdb_options_t* opt, unsigned char val);
@@ -2128,7 +2181,12 @@ enum {
   rocksdb_internal_range_del_reseek_count,
   rocksdb_block_read_cpu_time,
   rocksdb_internal_merge_point_lookup_count,
-  rocksdb_total_metric_count = 80
+  rocksdb_data_block_read_byte,
+  rocksdb_index_block_read_byte,
+  rocksdb_filter_block_read_byte,
+  rocksdb_compression_dict_block_read_byte,
+  rocksdb_metadata_block_read_byte,
+  rocksdb_total_metric_count = 85
 };
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_perf_level(int);
@@ -2265,9 +2323,6 @@ extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_tailing(
     rocksdb_readoptions_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_readoptions_get_tailing(
     rocksdb_readoptions_t*);
-// The functionality that this option controlled has been removed.
-extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_managed(
-    rocksdb_readoptions_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_readahead_size(
     rocksdb_readoptions_t*, size_t);
 extern ROCKSDB_LIBRARY_API size_t
@@ -2679,10 +2734,9 @@ rocksdb_slicetransform_create(
     char* (*transform)(void*, const char* key, size_t length,
                        size_t* dst_length),
     unsigned char (*in_domain)(void*, const char* key, size_t length),
-    unsigned char (*in_range)(void*, const char* key, size_t length),
     const char* (*name)(void*));
 extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
-    rocksdb_slicetransform_create_fixed_prefix(size_t);
+rocksdb_slicetransform_create_fixed_prefix(size_t);
 extern ROCKSDB_LIBRARY_API rocksdb_slicetransform_t*
 rocksdb_slicetransform_create_noop(void);
 extern ROCKSDB_LIBRARY_API void rocksdb_slicetransform_destroy(
@@ -2750,6 +2804,19 @@ rocksdb_fifo_compaction_options_set_max_table_files_size(
     rocksdb_fifo_compaction_options_t* fifo_opts, uint64_t size);
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_fifo_compaction_options_get_max_table_files_size(
+    rocksdb_fifo_compaction_options_t* fifo_opts);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_fifo_compaction_options_set_max_data_files_size(
+    rocksdb_fifo_compaction_options_t* fifo_opts, uint64_t size);
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_fifo_compaction_options_get_max_data_files_size(
+    rocksdb_fifo_compaction_options_t* fifo_opts);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_fifo_compaction_options_set_use_kv_ratio_compaction(
+    rocksdb_fifo_compaction_options_t* fifo_opts,
+    unsigned char use_kv_ratio_compaction);
+extern ROCKSDB_LIBRARY_API unsigned char
+rocksdb_fifo_compaction_options_get_use_kv_ratio_compaction(
     rocksdb_fifo_compaction_options_t* fifo_opts);
 extern ROCKSDB_LIBRARY_API void rocksdb_fifo_compaction_options_destroy(
     rocksdb_fifo_compaction_options_t* fifo_opts);
@@ -3631,6 +3698,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compaction_service(
 extern ROCKSDB_LIBRARY_API rocksdb_compaction_service_options_override_t*
 rocksdb_compaction_service_options_override_create(void);
 
+extern ROCKSDB_LIBRARY_API rocksdb_compaction_service_options_override_t*
+rocksdb_compaction_service_options_override_create_from_options(
+    rocksdb_options_t* option);
+
 extern ROCKSDB_LIBRARY_API void
 rocksdb_compaction_service_options_override_destroy(
     rocksdb_compaction_service_options_override_t* override_options);
@@ -3644,6 +3715,71 @@ extern ROCKSDB_LIBRARY_API void
 rocksdb_compaction_service_options_override_set_comparator(
     rocksdb_compaction_service_options_override_t* override_options,
     rocksdb_comparator_t* comparator);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_merge_operator(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_mergeoperator_t* merge_operator);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_compaction_filter(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_compactionfilter_t* compaction_filter);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_compaction_filter_factory(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_compactionfilterfactory_t* compaction_filter_factory);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_prefix_extractor(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_slicetransform_t* prefix_extractor);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_block_based_table_factory(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_block_based_table_options_t* table_options);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_cuckoo_table_factory(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_cuckoo_table_options_t* table_options);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_add_event_listener(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_eventlistener_t* event_listener);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_statistics(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_options_t* options);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_info_log(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_logger_t* logger);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_option(
+    rocksdb_compaction_service_options_override_t* override_options,
+    const char* key, const char* value);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_file_checksum_gen_factory(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_file_checksum_gen_factory_t* factory);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_set_sst_partitioner_factory(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_sst_partitioner_factory_t* factory);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_compaction_service_options_override_add_table_properties_collector_factory(
+    rocksdb_compaction_service_options_override_t* override_options,
+    rocksdb_table_properties_collector_factory_t* factory);
 
 // Atomic bool management for cancellation
 // Creates an atomic bool that can be used for cancellation.

--- a/db_test.go
+++ b/db_test.go
@@ -296,7 +296,6 @@ func newTestDBMultiCF(t *testing.T, columns []string, applyOpts func(opts *Optio
 	opts.SetCreateIfMissingColumnFamilies(true)
 	opts.SetCreateIfMissing(true)
 	opts.SetCompression(ZSTDCompression)
-	opts.SetSkipCheckingSSTFileSizesOnDBOpen(true)
 	opts.SetRateLimiter(NewRateLimiter(2<<30, 1<<20, 100<<20))
 	opts.SetUniversalCompactionOptions(NewDefaultUniversalCompactionOptions())
 

--- a/file_checksum.go
+++ b/file_checksum.go
@@ -1,0 +1,29 @@
+package grocksdb
+
+// #include "rocksdb/c.h"
+import "C"
+
+// FileChecksumGenFactory wraps a native file checksum generator factory used to
+// compute and verify per-file checksums for SST files.
+type FileChecksumGenFactory struct {
+	c *C.rocksdb_file_checksum_gen_factory_t
+}
+
+// NewCRC32CFileChecksumGenFactory creates a file checksum generator factory
+// that produces CRC32C checksums.
+func NewCRC32CFileChecksumGenFactory() *FileChecksumGenFactory {
+	return &FileChecksumGenFactory{
+		c: C.rocksdb_file_checksum_gen_crc32c_factory_create(),
+	}
+}
+
+// newNativeFileChecksumGenFactory wraps an existing native handle.
+func newNativeFileChecksumGenFactory(c *C.rocksdb_file_checksum_gen_factory_t) *FileChecksumGenFactory {
+	return &FileChecksumGenFactory{c: c}
+}
+
+// Destroy deallocates the FileChecksumGenFactory object.
+func (f *FileChecksumGenFactory) Destroy() {
+	C.rocksdb_file_checksum_gen_factory_destroy(f.c)
+	f.c = nil
+}

--- a/grocksdb.c
+++ b/grocksdb.c
@@ -60,6 +60,5 @@ rocksdb_slicetransform_t* gorocksdb_slicetransform_create(uintptr_t idx) {
     	gorocksdb_destruct_handler,
     	(char* (*)(void*, const char*, size_t, size_t*))(gorocksdb_slicetransform_transform),
     	(unsigned char (*)(void*, const char*, size_t))(gorocksdb_slicetransform_in_domain),
-    	(unsigned char (*)(void*, const char*, size_t))(gorocksdb_slicetransform_in_range),
     	(const char* (*)(void*))(gorocksdb_slicetransform_name));
 }

--- a/grocksdb.c
+++ b/grocksdb.c
@@ -62,3 +62,51 @@ rocksdb_slicetransform_t* gorocksdb_slicetransform_create(uintptr_t idx) {
     	(unsigned char (*)(void*, const char*, size_t))(gorocksdb_slicetransform_in_domain),
     	(const char* (*)(void*))(gorocksdb_slicetransform_name));
 }
+
+/* Logger */
+
+/* Trampoline: RocksDB invokes this with priv == the registry index, and we
+   forward to the exported Go callback. */
+static void gorocksdb_logger_logv(void* priv, unsigned lev, char* msg, size_t len) {
+    gorocksdb_logger_log((uintptr_t)priv, lev, msg, len);
+}
+
+rocksdb_logger_t* gorocksdb_logger_create_callback(int log_level, uintptr_t idx) {
+    return rocksdb_logger_create_callback_logger(log_level, gorocksdb_logger_logv, (void*)idx);
+}
+
+/* WriteBatch lazy-data iteration */
+
+/* Non-CF trampolines forward state (the registry index) to the exported Go
+   callbacks. */
+static void gorocksdb_wb_put(void* s, const char* k, size_t klen, const char* v, size_t vlen) {
+    gorocksdb_writebatch_put((uintptr_t)s, (char*)k, klen, (char*)v, vlen);
+}
+static void gorocksdb_wb_deleted(void* s, const char* k, size_t klen) {
+    gorocksdb_writebatch_deleted((uintptr_t)s, (char*)k, klen);
+}
+static void gorocksdb_wb_logdata(void* s, const char* blob, size_t blen) {
+    gorocksdb_writebatch_logdata((uintptr_t)s, (char*)blob, blen);
+}
+
+void gorocksdb_writebatch_iterate_ld(rocksdb_writebatch_t* wb, uintptr_t idx) {
+    rocksdb_writebatch_iterate_ld(wb, (void*)idx,
+        gorocksdb_wb_put, gorocksdb_wb_deleted, gorocksdb_wb_logdata);
+}
+
+/* CF trampolines. */
+static void gorocksdb_wb_put_cf(void* s, uint32_t cfid, const char* k, size_t klen, const char* v, size_t vlen) {
+    gorocksdb_writebatch_put_cf((uintptr_t)s, cfid, (char*)k, klen, (char*)v, vlen);
+}
+static void gorocksdb_wb_deleted_cf(void* s, uint32_t cfid, const char* k, size_t klen) {
+    gorocksdb_writebatch_deleted_cf((uintptr_t)s, cfid, (char*)k, klen);
+}
+static void gorocksdb_wb_merge_cf(void* s, uint32_t cfid, const char* k, size_t klen, const char* v, size_t vlen) {
+    gorocksdb_writebatch_merge_cf((uintptr_t)s, cfid, (char*)k, klen, (char*)v, vlen);
+}
+
+void gorocksdb_writebatch_iterate_cf_ld(rocksdb_writebatch_t* wb, uintptr_t idx) {
+    rocksdb_writebatch_iterate_cf_ld(wb, (void*)idx,
+        gorocksdb_wb_put_cf, gorocksdb_wb_deleted_cf, gorocksdb_wb_merge_cf,
+        gorocksdb_wb_logdata);
+}

--- a/grocksdb.h
+++ b/grocksdb.h
@@ -25,3 +25,12 @@ extern void gorocksdb_mergeoperator_delete_value(void* state, const char* v, siz
 /* Slice Transform */
 
 extern rocksdb_slicetransform_t* gorocksdb_slicetransform_create(uintptr_t idx);
+
+/* Logger */
+
+extern rocksdb_logger_t* gorocksdb_logger_create_callback(int log_level, uintptr_t idx);
+
+/* WriteBatch lazy-data iteration */
+
+extern void gorocksdb_writebatch_iterate_ld(rocksdb_writebatch_t* wb, uintptr_t idx);
+extern void gorocksdb_writebatch_iterate_cf_ld(rocksdb_writebatch_t* wb, uintptr_t idx);

--- a/logger.go
+++ b/logger.go
@@ -19,8 +19,34 @@ func NewStderrLogger(level InfoLogLevel, prefix string) *Logger {
 	}
 }
 
+// LogHandler is invoked for each log message emitted by RocksDB when a
+// callback logger is installed. level is the severity of the message.
+type LogHandler = func(level InfoLogLevel, msg string)
+
+// NewCallbackLogger creates a Logger that forwards every RocksDB log message
+// to the provided Go handler. Messages below level are filtered out by RocksDB.
+func NewCallbackLogger(level InfoLogLevel, handler LogHandler) *Logger {
+	idx := registerLogHandler(handler)
+	return &Logger{
+		c: C.gorocksdb_logger_create_callback(C.int(level), C.uintptr_t(idx)),
+	}
+}
+
 // Destroy Logger.
 func (l *Logger) Destroy() {
 	C.rocksdb_logger_destroy(l.c)
 	l.c = nil
+}
+
+// Hold references to log handlers so they survive across the cgo boundary.
+var logHandlers = NewCOWList()
+
+func registerLogHandler(handler LogHandler) int {
+	return logHandlers.Append(handler)
+}
+
+//export gorocksdb_logger_log
+func gorocksdb_logger_log(idx int, level C.uint, cMsg *C.char, cLen C.size_t) {
+	handler := logHandlers.Get(idx).(LogHandler)
+	handler(InfoLogLevel(level), C.GoStringN(cMsg, C.int(cLen)))
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,48 @@
+package grocksdb
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallbackLogger(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu      sync.Mutex
+		count   int64
+		lastMsg string
+		lastLvl InfoLogLevel
+	)
+
+	logger := NewCallbackLogger(DebugInfoLogLevel, func(level InfoLogLevel, msg string) {
+		atomic.AddInt64(&count, 1)
+		mu.Lock()
+		lastMsg = msg
+		lastLvl = level
+		mu.Unlock()
+	})
+
+	db := newTestDB(t, func(opts *Options) {
+		opts.SetInfoLog(logger)
+	})
+	defer db.Close()
+
+	// Generate some log activity.
+	wo := NewDefaultWriteOptions()
+	defer wo.Destroy()
+	require.NoError(t, db.Put(wo, []byte("foo"), []byte("bar")))
+	fo := NewDefaultFlushOptions()
+	defer fo.Destroy()
+	require.NoError(t, db.Flush(fo))
+
+	require.Greater(t, atomic.LoadInt64(&count), int64(0))
+
+	mu.Lock()
+	require.NotEmpty(t, lastMsg)
+	_ = lastLvl
+	mu.Unlock()
+}

--- a/options.go
+++ b/options.go
@@ -111,6 +111,8 @@ type Options struct {
 	cmo  *C.rocksdb_mergeoperator_t
 	cst  *C.rocksdb_slicetransform_t
 	ccf  *C.rocksdb_compactionfilter_t
+	cfcg *C.rocksdb_file_checksum_gen_factory_t
+	cspf *C.rocksdb_sst_partitioner_factory_t
 }
 
 // NewDefaultOptions creates the default Options.
@@ -511,6 +513,41 @@ func (opts *Options) SetMaxOpenFiles(value int) {
 // GetMaxOpenFiles gets the number of open files that can be used by the DB.
 func (opts *Options) GetMaxOpenFiles() int {
 	return int(C.rocksdb_options_get_max_open_files(opts.c))
+}
+
+// SetOpenFilesAsync enables opening SST files asynchronously (in parallel)
+// when the DB is opened, which can speed up open time for DBs with many files.
+//
+// Default: false
+func (opts *Options) SetOpenFilesAsync(value bool) {
+	C.rocksdb_options_set_open_files_async(opts.c, boolToChar(value))
+}
+
+// OpenFilesAsync checks whether files are opened asynchronously on DB open.
+func (opts *Options) OpenFilesAsync() bool {
+	return charToBool(C.rocksdb_options_get_open_files_async(opts.c))
+}
+
+// SetFileChecksumGenFactory sets the factory used to generate (and verify)
+// per-SST-file checksums.
+//
+// The Options takes ownership of the factory's native handle and frees it on
+// Destroy; callers should not also call Destroy on the factory.
+func (opts *Options) SetFileChecksumGenFactory(factory *FileChecksumGenFactory) {
+	C.rocksdb_file_checksum_gen_factory_destroy(opts.cfcg)
+	opts.cfcg = factory.c
+	C.rocksdb_options_set_file_checksum_gen_factory(opts.c, factory.c)
+}
+
+// SetSSTPartitionerFactory sets the factory that decides where compaction
+// output SST files should be cut.
+//
+// The Options takes ownership of the factory's native handle and frees it on
+// Destroy; callers should not also call Destroy on the factory.
+func (opts *Options) SetSSTPartitionerFactory(factory *SSTPartitionerFactory) {
+	C.rocksdb_sst_partitioner_factory_destroy(opts.cspf)
+	opts.cspf = factory.c
+	C.rocksdb_options_set_sst_partitioner_factory(opts.c, factory.c)
 }
 
 // SetMaxFileOpeningThreads sets the maximum number of file opening threads.
@@ -2807,6 +2844,12 @@ func (opts *Options) Destroy() {
 
 	C.rocksdb_mergeoperator_destroy(opts.cmo)
 	opts.cmo = nil
+
+	C.rocksdb_file_checksum_gen_factory_destroy(opts.cfcg)
+	opts.cfcg = nil
+
+	C.rocksdb_sst_partitioner_factory_destroy(opts.cspf)
+	opts.cspf = nil
 
 	if opts.env != nil {
 		C.rocksdb_env_destroy(opts.env)

--- a/options.go
+++ b/options.go
@@ -2274,18 +2274,6 @@ func (opts *Options) SkipStatsUpdateOnDBOpen() bool {
 	return charToBool(C.rocksdb_options_get_skip_stats_update_on_db_open(opts.c))
 }
 
-// SetSkipCheckingSSTFileSizesOnDBOpen skips checking sst file sizes on db openning
-//
-// Default: false
-func (opts *Options) SetSkipCheckingSSTFileSizesOnDBOpen(value bool) {
-	C.rocksdb_options_set_skip_checking_sst_file_sizes_on_db_open(opts.c, boolToChar(value))
-}
-
-// SkipCheckingSSTFileSizesOnDBOpen checks if skips_checking_sst_file_sizes_on_db_openning is set.
-func (opts *Options) SkipCheckingSSTFileSizesOnDBOpen() bool {
-	return charToBool(C.rocksdb_options_get_skip_checking_sst_file_sizes_on_db_open(opts.c))
-}
-
 /* Blob Options Settings */
 
 // EnableBlobFiles when set, large values (blobs) are written to separate blob files, and

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -49,6 +49,17 @@ const (
 	KDataBlockIndexTypeBinarySearchAndHash DataBlockIndexType = 1
 )
 
+// IndexBlockSearchType specifies the search type used within an index block.
+type IndexBlockSearchType int
+
+const (
+	// KBinarySearchIndexBlockSearchType uses binary search within the index block.
+	KBinarySearchIndexBlockSearchType IndexBlockSearchType = 0
+	// KInterpolationSearchIndexBlockSearchType uses interpolation search within
+	// the index block.
+	KInterpolationSearchIndexBlockSearchType IndexBlockSearchType = 1
+)
+
 // BlockBasedPinningTier is used to specify which tier of block-based tables should
 // be affected by a block cache pinning setting.
 type BlockBasedPinningTier int
@@ -245,6 +256,28 @@ func (opts *BlockBasedTableOptions) SetIndexType(value IndexType) {
 // SetDataBlockIndexType sets data block index type
 func (opts *BlockBasedTableOptions) SetDataBlockIndexType(value DataBlockIndexType) {
 	C.rocksdb_block_based_options_set_data_block_index_type(opts.c, C.int(value))
+}
+
+// SetIndexBlockSearchType sets the search type used within an index block.
+//
+// Default: KBinarySearchIndexBlockSearchType
+func (opts *BlockBasedTableOptions) SetIndexBlockSearchType(value IndexBlockSearchType) {
+	C.rocksdb_block_based_options_set_index_block_search_type(opts.c, C.int(value))
+}
+
+// SetSeparateKeyValueInDataBlock stores keys and values separately within a
+// data block when enabled.
+//
+// Default: false
+func (opts *BlockBasedTableOptions) SetSeparateKeyValueInDataBlock(value bool) {
+	C.rocksdb_block_based_options_set_separate_key_value_in_data_block(opts.c, boolToChar(value))
+}
+
+// SetBlockAlign aligns data blocks on the block size boundary when enabled.
+//
+// Default: false
+func (opts *BlockBasedTableOptions) SetBlockAlign(value bool) {
+	C.rocksdb_block_based_options_set_block_align(opts.c, boolToChar(value))
 }
 
 // SetDataBlockHashRatio is valid only when data_block_hash_index_type is

--- a/options_block_based_table_test.go
+++ b/options_block_based_table_test.go
@@ -15,4 +15,7 @@ func TestBBT(t *testing.T) {
 	b.SetTopLevelIndexPinningTier(KFallbackPinningTier)
 	b.SetPartitionPinningTier(KNonePinningTier)
 	b.SetUnpartitionedPinningTier(KAllPinningTier)
+	b.SetIndexBlockSearchType(KInterpolationSearchIndexBlockSearchType)
+	b.SetSeparateKeyValueInDataBlock(true)
+	b.SetBlockAlign(true)
 }

--- a/options_compaction.go
+++ b/options_compaction.go
@@ -177,6 +177,35 @@ func (opts *FIFOCompactionOptions) GetMaxTableFilesSize() uint64 {
 	return uint64(C.rocksdb_fifo_compaction_options_get_max_table_files_size(opts.c))
 }
 
+// SetMaxDataFilesSize sets the max size of all data files (excluding metadata
+// files such as blob files). Once the total sum of data files reaches this,
+// the oldest data file will be deleted.
+//
+// A value of 0 means this limit is not enforced.
+//
+// Default: 0
+func (opts *FIFOCompactionOptions) SetMaxDataFilesSize(value uint64) {
+	C.rocksdb_fifo_compaction_options_set_max_data_files_size(opts.c, C.uint64_t(value))
+}
+
+// GetMaxDataFilesSize gets the max size of all data files.
+func (opts *FIFOCompactionOptions) GetMaxDataFilesSize() uint64 {
+	return uint64(C.rocksdb_fifo_compaction_options_get_max_data_files_size(opts.c))
+}
+
+// SetUseKVRatioCompaction enables intra-L0 compaction triggered by the ratio
+// of garbage (deleted/overwritten) key-values to live key-values.
+//
+// Default: false
+func (opts *FIFOCompactionOptions) SetUseKVRatioCompaction(value bool) {
+	C.rocksdb_fifo_compaction_options_set_use_kv_ratio_compaction(opts.c, boolToChar(value))
+}
+
+// UseKVRatioCompaction checks if kv-ratio-triggered compaction is enabled.
+func (opts *FIFOCompactionOptions) UseKVRatioCompaction() bool {
+	return charToBool(C.rocksdb_fifo_compaction_options_get_use_kv_ratio_compaction(opts.c))
+}
+
 // SetAllowCompaction allows compaction or not.
 func (opts *FIFOCompactionOptions) SetAllowCompaction(allow bool) {
 	C.rocksdb_fifo_compaction_options_set_allow_compaction(opts.c, boolToChar(allow))

--- a/options_compaction_test.go
+++ b/options_compaction_test.go
@@ -52,6 +52,13 @@ func TestFifoCompactOption(t *testing.T) {
 	fo.SetMaxTableFilesSize(2 << 10)
 	require.EqualValues(t, 2<<10, fo.GetMaxTableFilesSize())
 
+	fo.SetMaxDataFilesSize(4 << 10)
+	require.EqualValues(t, 4<<10, fo.GetMaxDataFilesSize())
+
+	require.False(t, fo.UseKVRatioCompaction())
+	fo.SetUseKVRatioCompaction(true)
+	require.True(t, fo.UseKVRatioCompaction())
+
 	require.False(t, fo.AllowCompaction())
 	fo.SetAllowCompaction(true)
 	require.True(t, fo.AllowCompaction())

--- a/options_test.go
+++ b/options_test.go
@@ -343,10 +343,6 @@ func TestOptions(t *testing.T) {
 	opts.SetSkipStatsUpdateOnDBOpen(true)
 	require.EqualValues(t, true, opts.SkipStatsUpdateOnDBOpen())
 
-	require.EqualValues(t, false, opts.SkipCheckingSSTFileSizesOnDBOpen())
-	opts.SetSkipCheckingSSTFileSizesOnDBOpen(true)
-	require.EqualValues(t, true, opts.SkipCheckingSSTFileSizesOnDBOpen())
-
 	opts.CompactionReadaheadSize(88 << 20)
 	require.EqualValues(t, 88<<20, opts.GetCompactionReadaheadSize())
 

--- a/options_test.go
+++ b/options_test.go
@@ -467,3 +467,18 @@ func TestOptions2(t *testing.T) {
 		require.Empty(t, opts.GetStatisticsString())
 	})
 }
+
+func TestOptionsOpenFilesAsyncAndFactories(t *testing.T) {
+	t.Parallel()
+
+	opts := NewDefaultOptions()
+	defer opts.Destroy()
+
+	require.False(t, opts.OpenFilesAsync())
+	opts.SetOpenFilesAsync(true)
+	require.True(t, opts.OpenFilesAsync())
+
+	// Ownership of the factories is transferred to opts; freed on opts.Destroy().
+	opts.SetFileChecksumGenFactory(NewCRC32CFileChecksumGenFactory())
+	opts.SetSSTPartitionerFactory(NewFixedPrefixSSTPartitionerFactory(8))
+}

--- a/rocksdb-upgrade.md
+++ b/rocksdb-upgrade.md
@@ -1,0 +1,240 @@
+# grocksdb Maintenance Guide — Upgrading the bundled RocksDB
+
+This document describes how to bump **grocksdb** to a new **RocksDB** release. It
+is the repeatable recipe used for every `Adapt RocksDB X.Y.Z` commit (e.g.
+`5fc3d82` → 10.9.1, `632e53a` → 10.10.1, the 10.10.1 → 11.1.1 bump).
+
+grocksdb is a thin **CGO** binding: the Go code calls RocksDB's C API declared in
+RocksDB's `include/rocksdb/c.h`. To track a new RocksDB version you re-vendor that
+header and reconcile the Go/C glue with any API that was **added**, **removed**, or
+whose **signature changed**.
+
+---
+
+## TL;DR checklist
+
+1. **Bump the version** in `build.sh` (`rocksdb_version="X.Y.Z"`).
+2. **Diff RocksDB's `include/rocksdb/c.h`** between the old and new tag.
+3. **Apply that diff to the repo-root `c.h`** (the vendored copy grocksdb compiles against).
+4. **Reconcile the Go/C glue** for any *removed* or *signature-changed* C symbols
+   that this binding actually uses (`grocksdb.c`, `grocksdb.h`, `*.go`).
+5. **Update `README.md`** "API Support" with newly added but unwrapped C APIs.
+6. **Build & test** (`make test`).
+7. Commit as `CHORE Adapt RocksDB X.Y.Z`.
+
+---
+
+## Key files
+
+| File | Role |
+|------|------|
+| `build.sh` | Builds RocksDB + compression deps from source. Holds `rocksdb_version`. |
+| `c.h` (repo root) | **Vendored copy** of RocksDB's `include/rocksdb/c.h`. This is the source of truth the Go code binds to. Must match the target tag. |
+| `grocksdb.c` / `grocksdb.h` | Hand-written C shims that wrap callback-based C constructors (comparator, merge operator, slice transform, compaction filter). Sensitive to C API signature changes. |
+| `*.go` | The Go wrappers calling `C.rocksdb_*`. |
+| `non_builtin.go` / `non_builtin_clean_link.go` | CGO `LDFLAGS` for the `grocksdb_no_link` / `grocksdb_clean_link` build tags. |
+| `Makefile` | `make libs` runs `build.sh`; `make test` runs the tagged test suite. |
+| `README.md` | "API Support" section listing C APIs **not** wrapped in Go. |
+
+> `deps/` is a **gitignored build artifact** (a RocksDB checkout). Never hand-edit
+> `deps/rocksdb/include/rocksdb/c.h` — it is regenerated when you rebuild against
+> the new tag. Only the **repo-root** `c.h` matters for the binding.
+
+---
+
+## Step 1 — Bump `build.sh`
+
+```diff
+-rocksdb_version="10.10.1"
++rocksdb_version="11.1.1"
+```
+
+While you're here, sanity-check the compression library versions pinned above it
+(`snappy_version`, `zlib_version`, `lz4_version`, `zstd_version`). Bump them only if
+the new RocksDB requires it — usually they can stay. Note the deliberate
+`-DPORTABLE=1` (kept for CI runner CPU compatibility) and `-DWITH_BZ2=OFF`.
+
+---
+
+## Step 2 — Diff RocksDB's `c.h` between tags
+
+The only RocksDB file that affects the binding is `include/rocksdb/c.h`. Get a
+focused diff of just that header between the current and target tag.
+
+### Option A — from a RocksDB clone
+
+```bash
+git clone https://github.com/facebook/rocksdb.git
+cd rocksdb
+git fetch --tags
+# Old tag = what build.sh currently pins; new tag = target.
+git diff v10.10.1 v11.1.1 -- include/rocksdb/c.h
+```
+
+### Option B — from a full release diff you already have
+
+If you have a full source diff (e.g. `10-11.diff`), the header is one slice of it.
+Locate its hunk boundaries and read just that range:
+
+```bash
+# Find where the c.h diff starts and where the NEXT file diff starts.
+grep -n "^diff --git" 10-11.diff | grep -E "include/rocksdb/(c\.h|cache\.h)"
+# e.g. c.h begins at line 33691, the following file (cache.h) at 33964
+# → the c.h diff is lines 33691..33963.
+sed -n '33691,33963p' 10-11.diff
+```
+
+### Option C — GitHub compare URL
+
+`https://github.com/facebook/rocksdb/compare/v10.10.1...v11.1.1` then open
+`include/rocksdb/c.h` in the Files Changed tab.
+
+---
+
+## Step 3 — Classify every `c.h` change
+
+Read the diff and bucket each change. The bucket decides how much work it is.
+
+| Change type | What to do |
+|-------------|------------|
+| **Added** typedef / function / enum | Add it verbatim to repo-root `c.h`. No Go work required (it just becomes available; wrap it later if desired). |
+| **Removed** function / enum value | Delete it from repo-root `c.h`. **Then** check whether any Go/C code in this repo used it (Step 4) — if so, that code must change too. |
+| **Signature changed** (params added/removed/reordered) | Update the declaration in repo-root `c.h`, **and** update every caller in `grocksdb.c` / `*.go`. |
+| Cosmetic (whitespace/indent) | Match it to keep future diffs clean, but harmless. |
+| Counter/enum bumps (e.g. `rocksdb_total_metric_count = 80 → 85`) | Update the value so the enum stays in sync. |
+
+Apply additions/removals to the **repo-root `c.h`** to mirror the upstream header
+exactly. Keeping it byte-faithful to the tag makes the *next* upgrade a clean diff.
+
+> Example from the 11.1.1 bump: additions included the `writebatch_iterate_ld`
+> family, `block_align`, `open_files_async`, file-checksum / SST-partitioner /
+> table-properties-collector factories, FIFO `max_data_files_size`, and many
+> `compaction_service_options_override_*` setters. Removals were
+> `skip_checking_sst_file_sizes_on_db_open` (get/set), `readoptions_set_managed`,
+> and the **signature change** of `rocksdb_slicetransform_create` (the `in_range`
+> callback parameter was dropped).
+
+---
+
+## Step 4 — Reconcile the Go/C glue (the part that breaks the build)
+
+**Additions never break compilation.** Only **removals** and **signature changes**
+can, and only if this binding actually references the affected symbol. For each
+such symbol, grep the source (excluding the `deps/` artifact):
+
+```bash
+# Does any Go/C source use the removed/changed symbol?
+grep -rn "rocksdb_options_set_skip_checking_sst_file_sizes_on_db_open" \
+  --include=*.go --include=*.c --include=*.h . | grep -v deps/
+```
+
+Then fix what you find:
+
+- **Removed C symbol that Go wrapped** → delete the Go wrapper method and any
+  tests calling it.
+  Example (11.1.1): removed `Options.SetSkipCheckingSSTFileSizesOnDBOpen` /
+  `SkipCheckingSSTFileSizesOnDBOpen` from `options.go`, plus their uses in
+  `db_test.go` and `options_test.go`.
+
+- **Signature-changed C constructor wrapped by a shim in `grocksdb.c`** → update
+  the shim's call, and drop any now-unused `//export`ed Go callback.
+  Example (11.1.1): `rocksdb_slicetransform_create` lost its `in_range` callback,
+  so `gorocksdb_slicetransform_create` in `grocksdb.c` stopped passing it, and the
+  dead `//export gorocksdb_slicetransform_in_range` was removed from
+  `slice_transform.go`. The `InRange` method was **kept** on the public
+  `SliceTransform` interface (marked `Deprecated:`) to avoid breaking downstream
+  implementers — RocksDB simply no longer calls it.
+
+**Public-API stability rule:** prefer keeping exported Go identifiers when only the
+*underlying* C API was removed (mark them `Deprecated:`), unless the wrapper
+genuinely cannot function. Remove an exported method only when its sole purpose was
+to call a C symbol that no longer exists.
+
+After editing, format-check:
+
+```bash
+gofmt -l <files you touched>   # empty output = OK
+```
+
+---
+
+## Step 5 — Update `README.md` "API Support"
+
+The README lists C APIs that grocksdb does **not** yet wrap in Go. For each
+**newly added** C function that you did not wrap, add a `- [ ]` bullet (mirror the
+naming already used in that section). This sets expectations and tracks future work.
+
+Quick way to see which new APIs are unwrapped:
+
+```bash
+for s in set_block_align open_files_async file_checksum_gen sst_partitioner \
+         table_properties_collector iterate_ld max_data_files_size; do
+  echo -n "$s: "; grep -rl "$s" --include=*.go . | grep -v deps/ | tr '\n' ' '; echo
+done
+# Empty result for a symbol = not wrapped → list it in README.
+```
+
+---
+
+## Step 6 — Build & test
+
+```bash
+make libs          # runs build.sh: builds compression libs + RocksDB into dist/<os>_<arch>
+make test          # go test -race -v -count=1 -tags testing,grocksdb_no_link
+```
+
+Or point CGO at an existing build:
+
+```bash
+CGO_CFLAGS="-I/path/to/rocksdb/include" \
+CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lsnappy -llz4 -lzstd" \
+  go test -count=1 ./...
+```
+
+A **link error** mentioning an `undefined reference to rocksdb_<symbol>` almost
+always means the repo-root `c.h` declares a symbol that the rebuilt `librocksdb.a`
+no longer exports (a missed **removal**), or vice-versa (a missed **addition**).
+Re-run Step 3 against the exact tag.
+
+---
+
+## Step 7 — Commit
+
+Match the existing history style:
+
+```
+CHORE Adapt RocksDB 11.1.1
+```
+
+Typical touched files: `build.sh`, `c.h`, `README.md`, plus any `*.go` / `grocksdb.c`
+reconciled in Step 4.
+
+---
+
+## Reference: how past bumps looked
+
+Inspect prior upgrade commits to calibrate scope:
+
+```bash
+git log --oneline --grep="Adapt RocksDB"
+git show --stat 632e53a   # 10.10.1: README + build.sh + c.h only (pure additions)
+git show --stat 5fc3d82   # 10.9.1 : also touched several *.go (API churn that round)
+```
+
+- A **pure-addition** release (like 10.10.1) touches only `build.sh`, `c.h`, `README.md`.
+- A release with **removals/signature changes** (like 11.1.1) additionally touches
+  `grocksdb.c` and the affected `*.go`/test files — that's Step 4.
+
+---
+
+## Why these mechanics
+
+- **`grocksdb_no_link` / `grocksdb_clean_link` tags:** the default CGO `LDFLAGS`
+  (`non_builtin.go`) include `-ldl`, which is POSIX-only. `-tags grocksdb_no_link`
+  lets you supply the full link line via `CGO_LDFLAGS` instead. `make test` uses
+  `grocksdb_no_link`.
+- **Repo-root `c.h` is the contract.** The Go files `#include "rocksdb/c.h"`, but the
+  binding is validated against the vendored repo-root copy. Keeping it identical to
+  the chosen RocksDB tag is what makes upgrades a mechanical diff.
+- **`deps/` is disposable.** It's a gitignored RocksDB working tree; treat it as
+  cache, not source.

--- a/slice_transform.go
+++ b/slice_transform.go
@@ -13,6 +13,10 @@ type SliceTransform interface {
 	InDomain(src []byte) bool
 
 	// Determine whether dst=Transform(src) for some src.
+	//
+	// Deprecated: RocksDB removed the in_range callback from the C API
+	// (rocksdb_slicetransform_create) as of v11.x, so this method is no longer
+	// invoked by RocksDB. It is retained only for backward source compatibility.
 	InRange(src []byte) bool
 
 	// Return the name of this transformation.
@@ -75,13 +79,6 @@ func gorocksdb_slicetransform_in_domain(idx int, cKey *C.char, cKeyLen C.size_t)
 	key := refCBytes(cKey, cKeyLen)
 	inDomain := sliceTransforms.Get(idx).(sliceTransformWrapper).sliceTransform.InDomain(key)
 	return boolToChar(inDomain)
-}
-
-//export gorocksdb_slicetransform_in_range
-func gorocksdb_slicetransform_in_range(idx int, cKey *C.char, cKeyLen C.size_t) C.uchar {
-	key := refCBytes(cKey, cKeyLen)
-	inRange := sliceTransforms.Get(idx).(sliceTransformWrapper).sliceTransform.InRange(key)
-	return boolToChar(inRange)
 }
 
 //export gorocksdb_slicetransform_name

--- a/sst_partitioner.go
+++ b/sst_partitioner.go
@@ -1,0 +1,30 @@
+package grocksdb
+
+// #include "rocksdb/c.h"
+import "C"
+
+// SSTPartitionerFactory wraps a native SST partitioner factory. An SST
+// partitioner decides where output files should be cut during compaction.
+type SSTPartitionerFactory struct {
+	c *C.rocksdb_sst_partitioner_factory_t
+}
+
+// NewFixedPrefixSSTPartitionerFactory creates an SST partitioner factory that
+// forces SST files to be cut on a fixed-length key prefix boundary, so that
+// keys sharing the same prefix never span two files.
+func NewFixedPrefixSSTPartitionerFactory(prefixLen uint) *SSTPartitionerFactory {
+	return &SSTPartitionerFactory{
+		c: C.rocksdb_sst_partitioner_fixed_prefix_factory_create(C.size_t(prefixLen)),
+	}
+}
+
+// newNativeSSTPartitionerFactory wraps an existing native handle.
+func newNativeSSTPartitionerFactory(c *C.rocksdb_sst_partitioner_factory_t) *SSTPartitionerFactory {
+	return &SSTPartitionerFactory{c: c}
+}
+
+// Destroy deallocates the SSTPartitionerFactory object.
+func (f *SSTPartitionerFactory) Destroy() {
+	C.rocksdb_sst_partitioner_factory_destroy(f.c)
+	f.c = nil
+}

--- a/win-build.md
+++ b/win-build.md
@@ -74,13 +74,34 @@ This gives you:
 
 > Visual Studio / MSBuild and vcpkg are **not** required.
 
+### How the scripts find MSYS2 (UCRT64 root detection)
+
+Both `build-deps.ps1` and `build-grocksdb.ps1` locate the UCRT64 toolchain root
+in this order — the first hit wins:
+
+1. **`$env:UCRT64`** — explicit override pointing directly at the UCRT64 root
+   (e.g. `D:\msys64\ucrt64`). Used by CI runners (`msys2/setup-msys2`).
+2. **`$env:MSYS2_ROOT`** — MSYS2 install root; the scripts use `<root>\ucrt64`.
+3. **`C:\msys64`** — the standard MSYS2 install location.
+4. **Registry fallback** — the MSYS2 installer's uninstall entry
+   (`...\Windows\CurrentVersion\Uninstall`, `InstallLocation`) under HKCU/HKLM.
+
+If MSYS2 lives somewhere non-standard and wasn't installed via the installer
+(no registry entry), set one of the environment variables for the session:
+
+```powershell
+$env:MSYS2_ROOT = 'D:\tools\msys64'      # or:
+$env:UCRT64     = 'D:\tools\msys64\ucrt64'
+```
+
 ---
 
 ## Step 1 — build RocksDB: `build-deps.ps1`
 
 `build-deps.ps1` (in the repo root) does the following:
 
-1. Verifies the UCRT64 toolchain (`gcc.exe`, `g++.exe`, `cmake.exe`, `ninja.exe`).
+1. Locates the UCRT64 root (see *How the scripts find MSYS2* above) and verifies
+   the toolchain (`gcc.exe`, `g++.exe`, `cmake.exe`, `ninja.exe`).
 2. **Removes** an existing `./deps` if present, then **recreates** it.
 3. **Clones** RocksDB `v11.1.1` into `./deps/rocksdb`.
 4. Builds it as a **static** library with the UCRT64 GCC toolchain + CMake + Ninja.
@@ -148,7 +169,8 @@ powershell -ExecutionPolicy Bypass -File .\build-grocksdb.ps1
 
 What it does:
 
-1. Verifies the UCRT64 toolchain and that `deps\rocksdb\librocksdb.a` +
+1. Locates the UCRT64 root (same detection order as `build-deps.ps1`), then
+   verifies the toolchain and that `deps\rocksdb\librocksdb.a` +
    `deps\rocksdb\include\rocksdb\c.h` exist (i.e. `build-deps.ps1` ran).
 2. Sets the CGO toolchain (`CC`/`CXX` → UCRT64 GCC, `CGO_ENABLED=1`).
 3. Sets `CGO_CFLAGS`/`CGO_CXXFLAGS` to `-I deps\rocksdb\include`.

--- a/win-build.md
+++ b/win-build.md
@@ -1,6 +1,6 @@
 # Building grocksdb on Windows (static RocksDB, from source)
 
-This guide builds **RocksDB v10.10.1** from source as a **static library**
+This guide builds **RocksDB v11.1.1** from source as a **static library**
 (`librocksdb.a`) and then compiles and tests the **grocksdb** CGO binding against
 it, using the MSYS2 **UCRT64** GCC toolchain + **CMake** + **Ninja**, driven from
 **PowerShell**.
@@ -82,7 +82,7 @@ This gives you:
 
 1. Verifies the UCRT64 toolchain (`gcc.exe`, `g++.exe`, `cmake.exe`, `ninja.exe`).
 2. **Removes** an existing `./deps` if present, then **recreates** it.
-3. **Clones** RocksDB `v10.10.1` into `./deps/rocksdb`.
+3. **Clones** RocksDB `v11.1.1` into `./deps/rocksdb`.
 4. Builds it as a **static** library with the UCRT64 GCC toolchain + CMake + Ninja.
 5. Copies `librocksdb.a` next to `include/` for simple CGO link paths.
 
@@ -121,10 +121,10 @@ Result:
   assume a 3.5 policy baseline and configure anyway. It **must be quoted**;
   unquoted, PowerShell splits the token at the `.` and passes a stray `.5`.
 
-> **Why RocksDB v10.10.1?** This grocksdb checkout is written against the RocksDB
-> **10.10.1** C API (`rocksdb/c.h`), so we build that exact tag. Newer RocksDB
-> (11.x) changes the C API and won't link against this binding. RocksDB 10.10.1
-> also builds cleanly under the GCC in current UCRT64.
+> **Why RocksDB v11.1.1?** This grocksdb checkout is written against the RocksDB
+> **11.1.1** C API (`rocksdb/c.h`), so we build that exact tag. A different RocksDB
+> minor version may add or remove C API symbols and fail to link against this
+> binding. RocksDB 11.1.1 also builds cleanly under the GCC in current UCRT64.
 
 ---
 

--- a/win-build.md
+++ b/win-build.md
@@ -1,0 +1,221 @@
+# Building grocksdb on Windows (static RocksDB, from source)
+
+This guide builds **RocksDB v10.10.1** from source as a **static library**
+(`librocksdb.a`) and then compiles and tests the **grocksdb** CGO binding against
+it, using the MSYS2 **UCRT64** GCC toolchain + **CMake** + **Ninja**, driven from
+**PowerShell**.
+
+Everything is statically linked: RocksDB and its compression libraries are linked
+into the grocksdb test binaries with no runtime DLL dependency on `librocksdb`,
+`libstdc++`, `libgcc` or `libwinpthread`.
+
+## Layout
+
+RocksDB is cloned and built **inside this repo**, under `./deps`:
+
+```
+grocksdb/                      # this repo
+├── deps/                      # created/managed by build-deps.ps1 (git-ignored)
+│   └── rocksdb/               # RocksDB source + build
+│       ├── librocksdb.a       # static archive (copied next to include/)
+│       ├── include/           # rocksdb/*.h  (rocksdb/c.h is what grocksdb needs)
+│       └── build/             # CMake/Ninja build tree
+├── build-deps.ps1             # clones + builds RocksDB into ./deps/rocksdb
+└── build-grocksdb.ps1         # builds & tests grocksdb against ./deps/rocksdb
+```
+
+The static archive and headers end up at:
+
+```
+deps/rocksdb/librocksdb.a
+deps/rocksdb/include/                 (rocksdb/*.h)
+```
+
+> `./deps/` is already listed in this repo's `.gitignore`, so the cloned/built
+> dependency is never committed.
+
+---
+
+## Prerequisites — install these BEFORE running any script
+
+### 1. git and Go (from their homepages)
+
+- Git: https://git-scm.com/download/win
+- Go:  https://go.dev/doc/install
+
+### 2. MSYS2 + UCRT64 toolchain + CMake/Ninja
+
+Install MSYS2: https://www.msys2.org/
+
+Then open the **MSYS2 UCRT64** shell **once** and install the toolchain, CMake,
+Ninja, and the compression libraries RocksDB needs. After this, you never need the
+MSYS2 shell again — everything else runs from PowerShell.
+
+```bash
+pacman -Syu
+pacman -S --needed \
+  base-devel \
+  mingw-w64-ucrt-x86_64-toolchain \
+  mingw-w64-ucrt-x86_64-cmake \
+  mingw-w64-ucrt-x86_64-ninja \
+  git \
+  mingw-w64-ucrt-x86_64-lz4 \
+  mingw-w64-ucrt-x86_64-zstd \
+  mingw-w64-ucrt-x86_64-zlib \
+  mingw-w64-ucrt-x86_64-snappy \
+  mingw-w64-ucrt-x86_64-bzip2
+```
+
+This gives you:
+
+- `C:\msys64\ucrt64\bin\gcc.exe`, `g++.exe`, `cmake.exe`, `ninja.exe`
+- static `.a` archives for lz4 / zstd / zlib / snappy / bzip2 under
+  `C:\msys64\ucrt64\lib`, with headers under `C:\msys64\ucrt64\include`
+
+> Visual Studio / MSBuild and vcpkg are **not** required.
+
+---
+
+## Step 1 — build RocksDB: `build-deps.ps1`
+
+`build-deps.ps1` (in the repo root) does the following:
+
+1. Verifies the UCRT64 toolchain (`gcc.exe`, `g++.exe`, `cmake.exe`, `ninja.exe`).
+2. **Removes** an existing `./deps` if present, then **recreates** it.
+3. **Clones** RocksDB `v10.10.1` into `./deps/rocksdb`.
+4. Builds it as a **static** library with the UCRT64 GCC toolchain + CMake + Ninja.
+5. Copies `librocksdb.a` next to `include/` for simple CGO link paths.
+
+Run it from the repo root in PowerShell:
+
+```powershell
+.\build-deps.ps1
+```
+
+If PowerShell blocks the script (execution policy), run it once as:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\build-deps.ps1
+```
+
+Result:
+
+- `deps\rocksdb\librocksdb.a`
+- headers in `deps\rocksdb\include` (notably `deps\rocksdb\include\rocksdb\c.h`)
+
+### Notes on the RocksDB CMake flags
+
+- **`-G Ninja` + `-DCMAKE_C_COMPILER`/`-DCMAKE_CXX_COMPILER` → UCRT64 GCC.** This
+  forces a GCC/Ninja build instead of MSVC. `CC`/`CXX` are also exported by the
+  script.
+- **`-DROCKSDB_BUILD_SHARED=OFF`** + `--target rocksdb` builds only the static
+  `librocksdb.a` (no shared DLL, no tools/benchmarks/tests).
+- **Compression: `-DWITH_LZ4/ZSTD/ZLIB/SNAPPY/BZ2=ON`.** These match the libraries
+  installed via pacman above and the link flags used by `build-grocksdb.ps1`.
+- **`-DWITH_LIBURING=OFF`** — io_uring is Linux-only.
+- **`-DPORTABLE=ON`** avoids emitting CPU instructions the build host supports but a
+  target machine may not.
+- **`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`** (quoted) — CMake 4.x removed
+  compatibility with projects declaring `cmake_minimum_required(VERSION <3.5)`,
+  which some of RocksDB's bundled CMake files still do. The flag tells CMake to
+  assume a 3.5 policy baseline and configure anyway. It **must be quoted**;
+  unquoted, PowerShell splits the token at the `.` and passes a stray `.5`.
+
+> **Why RocksDB v10.10.1?** This grocksdb checkout is written against the RocksDB
+> **10.10.1** C API (`rocksdb/c.h`), so we build that exact tag. Newer RocksDB
+> (11.x) changes the C API and won't link against this binding. RocksDB 10.10.1
+> also builds cleanly under the GCC in current UCRT64.
+
+---
+
+## Step 2 — build & test grocksdb: `build-grocksdb.ps1`
+
+`build-grocksdb.ps1` points CGO at the static archive under `.\deps\rocksdb`,
+compiles the binding, and runs the test suite.
+
+Run it from the repo root in PowerShell:
+
+```powershell
+.\build-grocksdb.ps1            # compile + run tests
+.\build-grocksdb.ps1 -NoTest    # compile only
+```
+
+If PowerShell blocks the script (execution policy):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\build-grocksdb.ps1
+```
+
+What it does:
+
+1. Verifies the UCRT64 toolchain and that `deps\rocksdb\librocksdb.a` +
+   `deps\rocksdb\include\rocksdb\c.h` exist (i.e. `build-deps.ps1` ran).
+2. Sets the CGO toolchain (`CC`/`CXX` → UCRT64 GCC, `CGO_ENABLED=1`).
+3. Sets `CGO_CFLAGS`/`CGO_CXXFLAGS` to `-I deps\rocksdb\include`.
+4. Sets `CGO_LDFLAGS` to the full static link line (see below).
+5. `go build  -tags grocksdb_no_link ./...`
+6. `go test  -tags grocksdb_no_link -count=1 ./...`
+
+### Why `-tags grocksdb_no_link`
+
+By default grocksdb injects its own linker flags
+(`-lrocksdb -pthread -lstdc++ -ldl -lm -lzstd -llz4 -lz -lsnappy`). The `-ldl`
+entry is a **POSIX-only** library that does not exist on Windows/mingw, so the
+default flags fail to link. The `grocksdb_no_link` build tag disables grocksdb's
+built-in flags and lets us supply the complete link line via `CGO_LDFLAGS`.
+
+### The static link line (`CGO_LDFLAGS`)
+
+```
+-L<deps\rocksdb> -L<C:\msys64\ucrt64\lib>
+-lrocksdb
+-lzstd -llz4 -lz -lsnappy -lbz2
+-lstdc++ -lm -lpthread
+-lshlwapi -lrpcrt4 -lbcrypt -ldbghelp
+-static -static-libgcc -static-libstdc++
+```
+
+- **Link order matters with GCC static libs:** the consumer (`-lrocksdb`) comes
+  **before** the libraries it depends on (the compression libs), which come before
+  the C++/runtime libs, which come before the Windows system libs.
+- **Compression libs** (`-lzstd -llz4 -lz -lsnappy -lbz2`) come from
+  `C:\msys64\ucrt64\lib` and match the `-DWITH_*=ON` flags used to build RocksDB.
+- **`-lshlwapi -lrpcrt4 -lbcrypt -ldbghelp`** satisfy Windows API references in
+  recent RocksDB (`Path*`, `UuidCreate`, `BCrypt*`, `SymInitialize`). Drop any that
+  the linker reports as unused; add back if you see undefined `BCrypt*` /
+  `SymInitialize` / `Path*` symbols.
+- **`-static -static-libgcc -static-libstdc++`** produce binaries with no runtime
+  dependency on `libstdc++-6.dll` / `libgcc_s_seh-1.dll` / `libwinpthread-1.dll`.
+
+---
+
+## Using grocksdb in your own project on Windows
+
+After `build-deps.ps1` has produced `deps\rocksdb\librocksdb.a`, point your own
+`go build` at it the same way `build-grocksdb.ps1` does — set the UCRT64 GCC
+toolchain, then:
+
+```powershell
+$RocksDb = "C:\path\to\grocksdb\deps\rocksdb"
+$env:CGO_CFLAGS  = "-I$RocksDb\include"
+$env:CGO_LDFLAGS = "-L$RocksDb -L C:\msys64\ucrt64\lib -lrocksdb " +
+                   "-lzstd -llz4 -lz -lsnappy -lbz2 -lstdc++ -lm -lpthread " +
+                   "-lshlwapi -lrpcrt4 -lbcrypt -ldbghelp " +
+                   "-static -static-libgcc -static-libstdc++"
+go build -tags grocksdb_no_link .\...
+```
+
+## Verify static linking
+
+With `objdump` / `ldd` from `C:\msys64\ucrt64\bin` on PATH, build a test binary and
+inspect it:
+
+```powershell
+go test -c -tags grocksdb_no_link -o grocksdb.test.exe .
+ldd .\grocksdb.test.exe
+```
+
+It should list only Windows system DLLs (KERNEL32, ws2_32, ...) — **no**
+`librocksdb`, `libstdc++-6.dll`, `libgcc_s_seh-1.dll` or `libwinpthread-1.dll`. If
+those appear, the static CRT flags didn't take — re-check
+`-static -static-libgcc -static-libstdc++` in `build-grocksdb.ps1`.

--- a/write_batch.go
+++ b/write_batch.go
@@ -1,6 +1,7 @@
 package grocksdb
 
 // #include "rocksdb/c.h"
+// #include "grocksdb.h"
 import "C"
 
 import (
@@ -167,6 +168,77 @@ func (wb *WriteBatch) NewIterator() *WriteBatchIterator {
 		return &WriteBatchIterator{}
 	}
 	return &WriteBatchIterator{data: data[12:]}
+}
+
+// WriteBatchHandler receives callbacks while iterating over the records of a
+// WriteBatch via Iterate / IterateCF. The CF* methods are only invoked by
+// IterateCF; the non-CF Put/Delete are only invoked by Iterate. LogData is
+// invoked by both for blob entries added via PutLogData.
+//
+// The byte slices passed to handler methods are only valid for the duration of
+// the call; copy them if they must outlive it.
+type WriteBatchHandler interface {
+	Put(key, value []byte)
+	Delete(key []byte)
+	LogData(blob []byte)
+
+	PutCF(cf uint32, key, value []byte)
+	DeleteCF(cf uint32, key []byte)
+	MergeCF(cf uint32, key, value []byte)
+}
+
+// Iterate replays the batch into the provided handler using RocksDB's native
+// (lazy-data) iteration, invoking Put, Delete and LogData. This handles large
+// values that the pure-Go NewIterator cannot.
+func (wb *WriteBatch) Iterate(handler WriteBatchHandler) {
+	idx := writeBatchHandlers.Append(handler)
+	C.gorocksdb_writebatch_iterate_ld(wb.c, C.uintptr_t(idx))
+}
+
+// IterateCF is like Iterate but also reports the column family id for each
+// record and invokes the CF* handler methods (including MergeCF).
+func (wb *WriteBatch) IterateCF(handler WriteBatchHandler) {
+	idx := writeBatchHandlers.Append(handler)
+	C.gorocksdb_writebatch_iterate_cf_ld(wb.c, C.uintptr_t(idx))
+}
+
+// Hold references to write batch handlers across the cgo boundary.
+var writeBatchHandlers = NewCOWList()
+
+//export gorocksdb_writebatch_put
+func gorocksdb_writebatch_put(idx int, cKey *C.char, cKeyLen C.size_t, cVal *C.char, cValLen C.size_t) {
+	h := writeBatchHandlers.Get(idx).(WriteBatchHandler)
+	h.Put(refCBytes(cKey, cKeyLen), refCBytes(cVal, cValLen))
+}
+
+//export gorocksdb_writebatch_deleted
+func gorocksdb_writebatch_deleted(idx int, cKey *C.char, cKeyLen C.size_t) {
+	h := writeBatchHandlers.Get(idx).(WriteBatchHandler)
+	h.Delete(refCBytes(cKey, cKeyLen))
+}
+
+//export gorocksdb_writebatch_logdata
+func gorocksdb_writebatch_logdata(idx int, cBlob *C.char, cBlobLen C.size_t) {
+	h := writeBatchHandlers.Get(idx).(WriteBatchHandler)
+	h.LogData(refCBytes(cBlob, cBlobLen))
+}
+
+//export gorocksdb_writebatch_put_cf
+func gorocksdb_writebatch_put_cf(idx int, cf C.uint32_t, cKey *C.char, cKeyLen C.size_t, cVal *C.char, cValLen C.size_t) {
+	h := writeBatchHandlers.Get(idx).(WriteBatchHandler)
+	h.PutCF(uint32(cf), refCBytes(cKey, cKeyLen), refCBytes(cVal, cValLen))
+}
+
+//export gorocksdb_writebatch_deleted_cf
+func gorocksdb_writebatch_deleted_cf(idx int, cf C.uint32_t, cKey *C.char, cKeyLen C.size_t) {
+	h := writeBatchHandlers.Get(idx).(WriteBatchHandler)
+	h.DeleteCF(uint32(cf), refCBytes(cKey, cKeyLen))
+}
+
+//export gorocksdb_writebatch_merge_cf
+func gorocksdb_writebatch_merge_cf(idx int, cf C.uint32_t, cKey *C.char, cKeyLen C.size_t, cVal *C.char, cValLen C.size_t) {
+	h := writeBatchHandlers.Get(idx).(WriteBatchHandler)
+	h.MergeCF(uint32(cf), refCBytes(cKey, cKeyLen), refCBytes(cVal, cValLen))
 }
 
 // SetSavePoint records the state of the batch for future calls to RollbackToSavePoint().

--- a/write_batch_test.go
+++ b/write_batch_test.go
@@ -192,3 +192,45 @@ func TestDecodeVarint_ISSUE131(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteBatchIterateLD(t *testing.T) {
+	t.Parallel()
+
+	wb := NewWriteBatch()
+	defer wb.Destroy()
+
+	wb.Put([]byte("k1"), []byte("v1"))
+	wb.PutLogData([]byte("blob1"))
+	wb.Delete([]byte("k2"))
+	wb.Merge([]byte("k3"), []byte("v3"))
+
+	h := &recordingHandler{}
+	wb.Iterate(h)
+
+	require.Equal(t, []string{"k1"}, h.puts)
+	require.Equal(t, []string{"v1"}, h.putVals)
+	require.Equal(t, []string{"k2"}, h.deletes)
+	require.Equal(t, []string{"blob1"}, h.logs)
+}
+
+type recordingHandler struct {
+	puts, putVals, deletes, logs []string
+}
+
+func (h *recordingHandler) Put(key, value []byte) {
+	h.puts = append(h.puts, string(key))
+	h.putVals = append(h.putVals, string(value))
+}
+func (h *recordingHandler) Delete(key []byte)   { h.deletes = append(h.deletes, string(key)) }
+func (h *recordingHandler) LogData(blob []byte) { h.logs = append(h.logs, string(blob)) }
+func (h *recordingHandler) PutCF(cf uint32, key, value []byte) {
+	h.puts = append(h.puts, string(key))
+	h.putVals = append(h.putVals, string(value))
+}
+func (h *recordingHandler) DeleteCF(cf uint32, key []byte) {
+	h.deletes = append(h.deletes, string(key))
+}
+func (h *recordingHandler) MergeCF(cf uint32, key, value []byte) {
+	h.puts = append(h.puts, string(key))
+	h.putVals = append(h.putVals, string(value))
+}


### PR DESCRIPTION
./rocksdb-upgrade.md is for upgrading with latest rocksdb tag version using AI.

Adding ./win-build.md and msys2 workflow so that people wouldn't get lost supporting windows static builds.